### PR TITLE
Data storge in the client

### DIFF
--- a/packages/backend/src/controllers/router.ts
+++ b/packages/backend/src/controllers/router.ts
@@ -1,4 +1,10 @@
-import { decodeUUID, messageToLine, resultToMessage } from '../encoding';
+import {
+  decodeUUID,
+  messageToLine,
+  messageToNote,
+  noteToMessage,
+  resultToMessage
+} from '../encoding';
 import { ClientConnection } from '../models/client-connection';
 import {
   addWhiteboard,
@@ -55,6 +61,24 @@ export const dispatch = (
         console.warn(
           'Received LineDrawn message from client not connected to a whiteboard'
         );
+      }
+
+      break;
+    }
+    case 'createNote': {
+      const body = message.body.createNote;
+      const data = messageToNote(body.note!);
+
+      if (client.whiteboard) {
+        client.whiteboard.handleOperation({
+          type: OperationType.NOTE_ADD,
+          data: { note: data, triggeredBy: message.messsageId }
+        });
+      } else {
+        console.warn(
+          'Received createNote message from client not connected to a whiteboard'
+        );
+        // TODO return error
       }
 
       break;

--- a/packages/backend/src/controllers/router.ts
+++ b/packages/backend/src/controllers/router.ts
@@ -19,12 +19,10 @@ export const dispatch = (
     case 'getAllFiguresRequest': {
       if (client.whiteboard) {
         client.send({
-          body: {
-            $case: 'getAllFiguresResponse',
-            getAllFiguresResponse: {
-              // @ts-ignore: FIXME Figure and Note are not overlapping
-              notes: [...client.whiteboard.figures.values()].map(encodeNote)
-            }
+          $case: 'getAllFiguresResponse',
+          getAllFiguresResponse: {
+            // @ts-ignore: FIXME Figure and Note are not overlapping
+            notes: [...client.whiteboard.figures.values()].map(encodeNote)
           }
         });
       }
@@ -35,7 +33,7 @@ export const dispatch = (
       console.log(`Client wants to join whiteboard ${whiteboardId}`);
       const result = connectClient(client, whiteboardId);
 
-      const response = resultToMessage(result);
+      const response = resultToMessage(result, message.messsageId);
       client.send(response);
       break;
     }

--- a/packages/backend/src/encoding.ts
+++ b/packages/backend/src/encoding.ts
@@ -1,5 +1,10 @@
 import * as uuid from 'uuid';
-import { Line, ServerToClientMessage } from './protocol/protocol';
+import { Note } from './models/whiteboard';
+import {
+  Line,
+  ServerToClientMessage,
+  Note as NoteProto
+} from './protocol/protocol';
 import type { Result, UUID } from './types';
 
 export const encodeUUID = (id: UUID): Uint8Array =>
@@ -7,11 +12,20 @@ export const encodeUUID = (id: UUID): Uint8Array =>
 
 export const decodeUUID = (id: Uint8Array): UUID => uuid.stringify(id);
 
-export const resultToMessage = (result: Result): ServerToClientMessage => {
+export const resultToMessage = (
+  result: Result,
+  responseTo: string
+): ServerToClientMessage['body'] => {
   if (result.result === 'success') {
-    return { body: { $case: 'success', success: {} } };
+    return {
+      $case: 'success',
+      success: { triggeredBy: responseTo }
+    };
   } else {
-    return { body: { $case: 'error', error: { reason: result.reason } } };
+    return {
+      $case: 'error',
+      error: { triggeredBy: responseTo, reason: result.reason }
+    };
   }
 };
 
@@ -21,3 +35,17 @@ export const messageToLine = (data: Line) => {
     bitmap: new Map(data.bitmap.map(point => [point.coordinates!, point.value]))
   };
 };
+
+// TODO move to other module
+const encodeNote = (note: Note): NoteProto => ({
+  id: Uint8Array.from(uuid.parse(note.id)),
+  content: note.content,
+  coordinates: note.location
+});
+
+export const newServerToClientMessage = (
+  body: ServerToClientMessage['body']
+): ServerToClientMessage => ({
+  messsageId: uuid.v4(),
+  body
+});

--- a/packages/backend/src/encoding.ts
+++ b/packages/backend/src/encoding.ts
@@ -36,11 +36,15 @@ export const messageToLine = (data: Line) => {
   };
 };
 
-// TODO move to other module
-const encodeNote = (note: Note): NoteProto => ({
-  id: Uint8Array.from(uuid.parse(note.id)),
-  content: note.content,
-  coordinates: note.location
+export const noteToMessage = (note: Note): NoteProto => ({
+  ...note,
+  id: Uint8Array.from(uuid.parse(note.id))
+});
+
+export const messageToNote = (noteMsg: NoteProto): Note => ({
+  id: uuid.stringify(noteMsg.id),
+  text: noteMsg.text,
+  position: noteMsg.position!
 });
 
 export const newServerToClientMessage = (

--- a/packages/backend/src/models/whiteboard.ts
+++ b/packages/backend/src/models/whiteboard.ts
@@ -76,30 +76,30 @@ export class Whiteboard {
 
   handleOperation(op: Operation) {
     switch (op.type) {
-      case OperationType.FIGURE_MOVE: {
-        const { figureId, newCoords } = op.data;
-        const figure = this.figures.get(figureId);
-        if (!figure) {
-          throw new OperationError('Figure does not exist');
-        }
-        if (
-          newCoords.x < 0 ||
-          newCoords.x > this.MAX_WIDTH ||
-          newCoords.y < 0 ||
-          newCoords.y > this.MAX_HEIGHT
-        ) {
-          throw new OperationError('New coords not allowed');
-        }
-        figure.location = newCoords;
-        this.sendToClients({
-          $case: 'figureMoved',
-          figureMoved: {
-            figureId: uuidStringToBytes(figure.id),
-            newCoordinates: newCoords
-          }
-        });
-        break;
-      }
+      // case OperationType.FIGURE_MOVE: {
+      //   const { figureId, newCoords } = op.data;
+      //   const figure = this.notes.get(figureId);
+      //   if (!figure) {
+      //     throw new OperationError('Figure does not exist');
+      //   }
+      //   if (
+      //     newCoords.x < 0 ||
+      //     newCoords.x > this.MAX_WIDTH ||
+      //     newCoords.y < 0 ||
+      //     newCoords.y > this.MAX_HEIGHT
+      //   ) {
+      //     throw new OperationError('New coords not allowed');
+      //   }
+      //   figure.location = newCoords;
+      //   this.sendToClients({
+      //     $case: 'figureMoved',
+      //     figureMoved: {
+      //       figureId: uuidStringToBytes(figure.id),
+      //       newCoordinates: newCoords
+      //     }
+      //   });
+      //   break;
+      // }
       case OperationType.LINE_ADD: {
         const line = op.data.line;
         this.lines.set(line.id, line);
@@ -136,7 +136,7 @@ export class Whiteboard {
       // case OperationType.RETURN_ALL_FIGURES: {
       //   // FIXME send only to requester
       //   this.sendToClients(
-      //     new GetAllRespMsg(Array.from(this.figures.values()))
+      //     new GetAllRespMsg(Array.from(this.notes.values()))
       //   );
       // }
     }

--- a/packages/backend/src/models/whiteboard.ts
+++ b/packages/backend/src/models/whiteboard.ts
@@ -95,12 +95,10 @@ export class Whiteboard {
         }
         figure.location = newCoords;
         this.sendToClients({
-          body: {
-            $case: 'figureMoved',
-            figureMoved: {
-              figureId: uuidStringToBytes(figure.id),
-              newCoordinates: newCoords
-            }
+          $case: 'figureMoved',
+          figureMoved: {
+            figureId: uuidStringToBytes(figure.id),
+            newCoordinates: newCoords
           }
         });
         break;
@@ -112,15 +110,13 @@ export class Whiteboard {
         console.log(`There are ${this.lines.size} lines on the whiteboard`);
 
         this.sendToClients({
-          body: {
-            $case: 'lineDrawn',
-            lineDrawn: {
-              id: encodeUUID(line.id),
-              bitmap: Array.from(line.bitmap.entries()).map(entry => ({
-                coordinates: entry[0],
-                value: entry[1]
-              }))
-            }
+          $case: 'lineDrawn',
+          lineDrawn: {
+            id: encodeUUID(line.id),
+            bitmap: Array.from(line.bitmap.entries()).map(entry => ({
+              coordinates: entry[0],
+              value: entry[1]
+            }))
           }
         });
         break;
@@ -134,7 +130,7 @@ export class Whiteboard {
     }
   }
 
-  protected sendToClients(message: ServerToClientMessage) {
+  protected sendToClients(message: ServerToClientMessage['body']) {
     console.log(`Sending message to ${this.clients.length} clients:`, message);
     this.clients.forEach(client => {
       client.send(message);

--- a/packages/client/src/editor/components/Editor.tsx
+++ b/packages/client/src/editor/components/Editor.tsx
@@ -19,7 +19,7 @@ import {
   startLine,
   undo
 } from '../whiteboard';
-import { addNote } from '../../store/notes';
+import { localAddNote } from '../../store/notes';
 import Tools from './Tools';
 import UndoTool from './UndoTool';
 import Stickies from './Stickies';
@@ -45,7 +45,7 @@ const Editor = (props: { x: number; y: number }) => {
       } else if (mode === 'erase') {
         startErase(point);
       } else if (mode === 'note') {
-        addNote(point);
+        localAddNote(point);
       }
     },
     [mode]

--- a/packages/client/src/editor/components/Editor.tsx
+++ b/packages/client/src/editor/components/Editor.tsx
@@ -19,10 +19,11 @@ import {
   startLine,
   undo
 } from '../whiteboard';
-import { addNote } from './Stickies';
+import { addNote } from '../../store/notes';
 import Tools from './Tools';
 import UndoTool from './UndoTool';
 import Stickies from './Stickies';
+import { useGlobalStore } from '../../store/hook';
 
 const Editor = (props: { x: number; y: number }) => {
   const { connection: serverConnection } = useContext(ServerContext);
@@ -107,6 +108,8 @@ const Editor = (props: { x: number; y: number }) => {
     };
   }, [handlePointerMove, handlePointerDown, handlePointerUp]);
 
+  const [globalStore] = useGlobalStore();
+
   // Main render function
   useEffect(() => {
     const timer = setInterval(() => render(getCtx()!, canvas.current!), 500);
@@ -125,7 +128,7 @@ const Editor = (props: { x: number; y: number }) => {
         <Tools />
         <UndoTool onClick={renderUndo} />
       </div>
-      <Stickies />
+      <Stickies notes={Array.from(globalStore.notes.values())} />
       <canvas
         ref={canvas}
         height={props.y}

--- a/packages/client/src/editor/components/Editor.tsx
+++ b/packages/client/src/editor/components/Editor.tsx
@@ -23,7 +23,7 @@ import { addNote } from '../../store/notes';
 import Tools from './Tools';
 import UndoTool from './UndoTool';
 import Stickies from './Stickies';
-import { useGlobalStore } from '../../store/hook';
+import { useGlobalStore } from '../../store';
 
 const Editor = (props: { x: number; y: number }) => {
   const { connection: serverConnection } = useContext(ServerContext);

--- a/packages/client/src/editor/components/Stickies.tsx
+++ b/packages/client/src/editor/components/Stickies.tsx
@@ -52,7 +52,7 @@ const getNote = (id: UUID) => {
   } else return 'Note with ${id} not found';
 };
 
-const Stickies = () => {
+const Stickies: React.FunctionComponent<{ notes: Note[] }> = ({ notes }) => {
   console.log({ notes });
   const listItems = notes.map(note => (
     <StickyNote

--- a/packages/client/src/editor/components/Stickies.tsx
+++ b/packages/client/src/editor/components/Stickies.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { deleteNote, updateText } from '../../store/notes';
+import { localDeleteNote, localUpdateText } from '../../store/notes';
 import { Note } from '../../types';
 import StickyNote from './StickyNote';
 
@@ -8,8 +8,8 @@ const Stickies: React.FunctionComponent<{ notes: Note[] }> = ({ notes }) => (
     {notes.map(note => (
       <StickyNote
         key={note.id}
-        save={updateText}
-        delete={deleteNote}
+        save={localUpdateText}
+        delete={localDeleteNote}
         note={note}
       />
     ))}

--- a/packages/client/src/editor/components/Stickies.tsx
+++ b/packages/client/src/editor/components/Stickies.tsx
@@ -1,73 +1,19 @@
 import React from 'react';
-import { v5 } from 'uuid';
-import { Coordinates, Note, UUID } from '../../types';
+import { deleteNote, updateText } from '../../store/notes';
+import { Note } from '../../types';
 import StickyNote from './StickyNote';
 
-const UUID_NAMESPACE = '940beed9-f057-4088-a714-a9f5f2fc6052';
-
-interface prop {
-  get: (id: UUID) => string;
-  save: (content: string, id: UUID) => void;
-  remove: (id: UUID) => void;
-}
-
-export const notes: Note[] = [];
-
-export const addNote = (pos: Coordinates) => {
-  notes.push({
-    id: v5('line' + (notes.length - 1).toString(), UUID_NAMESPACE),
-    position: pos,
-    text: ''
-  });
-  console.log('added note');
-};
-
-const moveNote = (id: UUID, newPos: Coordinates) => {
-  let index = notes.findIndex(note => note.id == id);
-  if (index != -1) {
-    notes[index].position = newPos;
-  }
-};
-
-const updateNote = (content: string, id: UUID) => {
-  console.log('updating note', { id, content });
-  let index = notes.findIndex(note => note.id == id);
-  if (index != -1) {
-    notes[index].text = content;
-    console.log('updated note', { id, content });
-  }
-};
-
-const deleteNote = (id: UUID) => {
-  let index = notes.findIndex(note => note.id == id);
-  if (index != -1) {
-    notes.splice(index, 1);
-  }
-};
-
-const getNote = (id: UUID) => {
-  let index = notes.findIndex(note => note.id == id);
-  if (index != -1) {
-    return notes[index].text;
-  } else return 'Note with ${id} not found';
-};
-
-const Stickies: React.FunctionComponent<{ notes: Note[] }> = ({ notes }) => {
-  console.log({ notes });
-  const listItems = notes.map(note => (
-    <StickyNote
-      key={note.id}
-      save={updateNote}
-      delete={deleteNote}
-      note={note}
-    />
-  ));
-
-  return (
-    <div id="stickies" className="stickersRoot">
-      {listItems}
-    </div>
-  );
-};
+const Stickies: React.FunctionComponent<{ notes: Note[] }> = ({ notes }) => (
+  <div id="stickies" className="stickersRoot">
+    {notes.map(note => (
+      <StickyNote
+        key={note.id}
+        save={updateText}
+        delete={deleteNote}
+        note={note}
+      />
+    ))}
+  </div>
+);
 
 export default Stickies;

--- a/packages/client/src/editor/components/Stickies.tsx
+++ b/packages/client/src/editor/components/Stickies.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useState } from 'react';
 import StickyNote, { NoteProps } from './StickyNote';
-import { UUID, Coordinate, Note } from '../../types';
+import { UUID, Coordinates, Note } from '../../types';
 import { v5 } from 'uuid';
 import { Notes } from '@material-ui/icons';
 
@@ -14,7 +14,7 @@ interface prop {
 
 export const notes: Note[] = [];
 
-export const addNote = (pos: Coordinate) => {
+export const addNote = (pos: Coordinates) => {
   notes.push({
     UUID: v5('line' + (notes.length - 1).toString(), UUID_NAMESPACE),
     position: pos,
@@ -23,7 +23,7 @@ export const addNote = (pos: Coordinate) => {
   console.log('added note');
 };
 
-const moveNote = (id: UUID, newPos: Coordinate) => {
+const moveNote = (id: UUID, newPos: Coordinates) => {
   let index = notes.findIndex(note => note.UUID == id);
   if (index != -1) {
     notes[index].position = newPos;

--- a/packages/client/src/editor/components/StickyNote.tsx
+++ b/packages/client/src/editor/components/StickyNote.tsx
@@ -4,13 +4,9 @@ import DeleteIcon from '@material-ui/icons/Delete';
 import { UUID, Note } from '../../types';
 
 interface NoteProps {
-  save: (content: string, id: UUID) => void;
+  save: (id: UUID, content: string) => void;
   delete: (id: UUID) => void;
   note: Note;
-}
-interface NoteState {
-  editing: boolean;
-  _newText: string;
 }
 
 const noteStyle = {
@@ -36,7 +32,7 @@ const StickyNote: React.FunctionComponent<NoteProps> = props => {
   const save = (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
     setIsEditing(false);
-    props.save(newText, note.id);
+    props.save(note.id, newText);
   };
 
   const deleteNote = () => {

--- a/packages/client/src/editor/math.ts
+++ b/packages/client/src/editor/math.ts
@@ -1,6 +1,6 @@
-import { Coordinate } from '../types';
+import { Coordinates } from '../types';
 
-export function linePoints(a: Coordinate, b: Coordinate) {
+export function linePoints(a: Coordinates, b: Coordinates) {
   let xDiff = b.x - a.x;
   let yDiff = b.y - a.y;
 
@@ -19,7 +19,7 @@ export function linePoints(a: Coordinate, b: Coordinate) {
 }
 
 // This function returns the pixels to be erased between two sampled around a specified radius of a square of pixels
-export function erasePoints(a: Coordinate, b: Coordinate) {
+export function erasePoints(a: Coordinates, b: Coordinates) {
   let radius = 3; //px
 
   let xDiff = b.x - a.x;

--- a/packages/client/src/editor/whiteboard.tsx
+++ b/packages/client/src/editor/whiteboard.tsx
@@ -1,4 +1,4 @@
-import { Coordinate, Line, UUID, Action, Note, Img } from '../types';
+import { Coordinates, Line, UUID, Action, Note, Img } from '../types';
 import { linePoints, erasePoints } from './math';
 import { serverConnection } from '../connection-context/server-connection';
 import { v5 } from 'uuid';
@@ -12,24 +12,24 @@ export const images: Img[] = [];
 let drawing = false;
 let erasing = false;
 
-let lastPos: Coordinate | null = null;
-let eraseBuffer: Coordinate[] = [];
-let erasedPixels: Map<UUID, Coordinate[]> = new Map<UUID, Coordinate[]>();
+let lastPos: Coordinates | null = null;
+let eraseBuffer: Coordinates[] = [];
+let erasedPixels: Map<UUID, Coordinates[]> = new Map<UUID, Coordinates[]>();
 
 // TODO using v5 is temporary; generate random v4 UUIDs
 const UUID_NAMESPACE = '940beed9-f057-4088-a714-a9f5f2fc6052';
 
-export const startLine = (point: Coordinate) => {
+export const startLine = (point: Coordinates) => {
   drawing = true;
   bitmap.push({
     UUID: v5('line' + (bitmap.length - 1).toString(), UUID_NAMESPACE),
-    points: new Map<Coordinate, number>()
+    points: new Map<Coordinates, number>()
   }); // placeholder UUID
   bitmap[bitmap.length - 1].points.set(point, 1);
   lastPos = point;
 };
 
-export const appendLine = (point: Coordinate) => {
+export const appendLine = (point: Coordinates) => {
   if (!drawing) {
     return;
   }
@@ -52,16 +52,16 @@ export const finishLine = () => {
   serverConnection.connection.publishLine(bitmap[bitmap.length - 1]);
 };
 
-export const startErase = (point: Coordinate) => {
+export const startErase = (point: Coordinates) => {
   erasing = true;
   eraseBuffer = [];
-  erasedPixels = new Map<UUID, Coordinate[]>();
+  erasedPixels = new Map<UUID, Coordinates[]>();
   //eraseIndex++;
   eraseBuffer.push(point);
   lastPos = point;
 };
 
-export const appendErase = (point: Coordinate) => {
+export const appendErase = (point: Coordinates) => {
   if (!erasing) {
     return;
   }

--- a/packages/client/src/serverClient.ts
+++ b/packages/client/src/serverClient.ts
@@ -10,15 +10,9 @@ import {
 import * as whiteboard from './editor/whiteboard';
 import { setServerState } from './store/notes';
 
-declare interface ServerConnectionEvents {
-  disconnect: () => void;
-  message: (decoded: Message) => void;
-}
-
-export class ServerConnection extends TypedEmitter<ServerConnectionEvents> {
+export class ServerConnection {
   socket: WebSocket;
   constructor(socket: WebSocket) {
-    super();
     this.socket = socket;
     this.socket.binaryType = 'arraybuffer';
     this.socket.onmessage = event => this.dispatch(event);

--- a/packages/client/src/serverClient.ts
+++ b/packages/client/src/serverClient.ts
@@ -1,7 +1,7 @@
 import { TypedEmitter } from 'tiny-typed-emitter';
 import type { UUID } from './types';
 import * as uuid from 'uuid';
-import { Message, Coordinate, Line } from './types';
+import { Message, Coordinates, Line } from './types';
 import {
   ClientToServerMessage,
   ServerToClientMessage

--- a/packages/client/src/serverClient.ts
+++ b/packages/client/src/serverClient.ts
@@ -49,12 +49,18 @@ export class ServerConnection extends TypedEmitter<ServerConnectionEvents> {
       }))
     };
 
-    const encoded = ClientToServerMessage.encode({
-      body: { $case: 'lineDrawn', lineDrawn }
-    }).finish();
+    const encoded = ClientToServerMessage.encode(
+      newClientToServerMessage({ $case: 'lineDrawn', lineDrawn })
+    ).finish();
 
     this.socket.send(encoded);
   }
+}
+
+function newClientToServerMessage(
+  body: ClientToServerMessage['body']
+): ClientToServerMessage {
+  return { messsageId: uuid.v4(), body };
 }
 
 // TODO deduplciate with backend code

--- a/packages/client/src/store/hook.ts
+++ b/packages/client/src/store/hook.ts
@@ -1,0 +1,24 @@
+import { useEffect, useState } from 'react';
+import { getCombinedState, CombinedState } from '.';
+
+let listeners: React.Dispatch<React.SetStateAction<CombinedState>>[] = [];
+
+export const useGlobalStore = () => {
+  const [state, setState] = useState(getCombinedState());
+  useEffect(() => {
+    listeners.push(setState);
+    return () => {
+      listeners = listeners.filter(l => l !== setState);
+    };
+  }, []);
+
+  listeners.push(setState);
+  return [state];
+};
+
+export const sendUpdate = () => {
+  const newState = getCombinedState();
+  for (const listener of listeners) {
+    listener(newState);
+  }
+};

--- a/packages/client/src/store/index.ts
+++ b/packages/client/src/store/index.ts
@@ -1,8 +1,20 @@
-const notes: any[] = [];
-const notesDrafts: any[] = [];
+import type { Note } from '../types';
+import { removeNullish } from '../utils';
+import { getNewestLocalState, NoteTimeline } from './note';
 
-export const getCombinedState = () => {
+const noteTimelines: Map<Note['id'], NoteTimeline> = new Map();
+
+export type CombinedState = {
+  notes: Map<Note['id'], Note>;
+};
+
+export const getCombinedState = (): CombinedState => {
+  const noteTimelinesArray = Array.from(noteTimelines.values());
   return {
-    notes: notes.concat(notesDrafts)
+    notes: new Map(
+      removeNullish(
+        noteTimelinesArray.map(nt => getNewestLocalState(nt))
+      ).map(note => [note.id, note])
+    )
   };
 };

--- a/packages/client/src/store/index.ts
+++ b/packages/client/src/store/index.ts
@@ -1,0 +1,8 @@
+const notes: any[] = [];
+const notesDrafts: any[] = [];
+
+export const getCombinedState = () => {
+  return {
+    notes: notes.concat(notesDrafts)
+  };
+};

--- a/packages/client/src/store/index.ts
+++ b/packages/client/src/store/index.ts
@@ -1,15 +1,21 @@
 import type { Note } from '../types';
 import { removeNullish } from '../utils';
-import { getNewestLocalState, NoteTimeline } from './note';
+import { sendUpdate } from './hook';
+import { getNewestLocalState, NoteTimeline } from './timelines/note';
 
-const noteTimelines: Map<Note['id'], NoteTimeline> = new Map();
+type Store = {
+  noteTimelines: Map<Note['id'], NoteTimeline>;
+};
+let store: Store = {
+  noteTimelines: new Map()
+};
 
 export type CombinedState = {
   notes: Map<Note['id'], Note>;
 };
 
 export const getCombinedState = (): CombinedState => {
-  const noteTimelinesArray = Array.from(noteTimelines.values());
+  const noteTimelinesArray = Array.from(store.noteTimelines.values());
   return {
     notes: new Map(
       removeNullish(
@@ -17,4 +23,10 @@ export const getCombinedState = (): CombinedState => {
       ).map(note => [note.id, note])
     )
   };
+};
+
+export const updateStore = (callback: (store: Store) => void): void => {
+  /** Callback should mutate the store */
+  callback(store);
+  sendUpdate();
 };

--- a/packages/client/src/store/index.ts
+++ b/packages/client/src/store/index.ts
@@ -14,6 +14,8 @@ export type CombinedState = {
   notes: Map<Note['id'], Note>;
 };
 
+export { useGlobalStore } from './hook';
+
 export const getCombinedState = (): CombinedState => {
   const noteTimelinesArray = Array.from(store.noteTimelines.values());
   return {

--- a/packages/client/src/store/note.ts
+++ b/packages/client/src/store/note.ts
@@ -1,0 +1,44 @@
+import type { Note, Coordinates } from '../types';
+
+type NoteTimeline = {
+  commited: Note | null;
+  draft: Note | null;
+};
+
+export const setDraftText = (
+  nt: NoteTimeline,
+  newText: string
+): NoteTimeline => {
+  const current = nt.draft ?? nt.commited;
+  if (!current) {
+    return nt;
+    console.error('moveNote called on Timeline with both states null');
+  } else {
+    return {
+      ...nt,
+      draft: {
+        ...current,
+        text: newText
+      }
+    };
+  }
+};
+
+export const moveNote = (
+  nt: NoteTimeline,
+  newPos: Coordinates
+): NoteTimeline => {
+  const current = nt.draft ?? nt.commited;
+  if (!current) {
+    return nt;
+    console.error('moveNote called on Timeline with both states null');
+  } else {
+    return {
+      ...nt,
+      draft: {
+        ...current,
+        position: newPos
+      }
+    };
+  }
+};

--- a/packages/client/src/store/note.ts
+++ b/packages/client/src/store/note.ts
@@ -1,25 +1,43 @@
-import type { Note, Coordinates } from '../types';
+import { v4 } from 'uuid';
+import type { Note, Coordinates, UUID } from '../types';
+
+type Patch = {
+  changeId: UUID;
+  newState: Note;
+};
 
 type NoteTimeline = {
   commited: Note | null;
-  draft: Note | null;
+  drafts: Patch[];
 };
+
+export const getNewestLocalState = (nt: NoteTimeline): Note | null => {
+  if (nt.drafts.length > 0) {
+    return nt.drafts[nt.drafts.length - 1].newState;
+  } else {
+    return nt.commited;
+  }
+};
+
+const newPatch = (newState: Note) => ({ changeId: v4(), newState });
 
 export const setDraftText = (
   nt: NoteTimeline,
   newText: string
 ): NoteTimeline => {
-  const current = nt.draft ?? nt.commited;
+  const current = getNewestLocalState(nt);
   if (!current) {
-    return nt;
     console.error('moveNote called on Timeline with both states null');
+    return nt;
   } else {
     return {
       ...nt,
-      draft: {
-        ...current,
-        text: newText
-      }
+      drafts: nt.drafts.concat(
+        newPatch({
+          ...current,
+          text: newText
+        })
+      )
     };
   }
 };
@@ -28,14 +46,14 @@ export const moveNote = (
   nt: NoteTimeline,
   newPos: Coordinates
 ): NoteTimeline => {
-  const current = nt.draft ?? nt.commited;
+  const current = nt.drafts ?? nt.commited;
   if (!current) {
     return nt;
     console.error('moveNote called on Timeline with both states null');
   } else {
     return {
       ...nt,
-      draft: {
+      drafts: {
         ...current,
         position: newPos
       }

--- a/packages/client/src/store/note.ts
+++ b/packages/client/src/store/note.ts
@@ -8,7 +8,7 @@ type Patch = {
   diff: Diff;
 };
 
-type NoteTimeline = {
+export type NoteTimeline = {
   noteId: UUID;
   commited: Note | null;
   patches: Patch[];

--- a/packages/client/src/store/notes.ts
+++ b/packages/client/src/store/notes.ts
@@ -1,5 +1,6 @@
 import { v4 } from 'uuid';
 import { updateStore } from '.';
+import { serverConnection } from '../connection-context/server-connection';
 import { Coordinates, Note } from '../types';
 import {
   newLocalNoteTimeline,
@@ -18,8 +19,12 @@ export const localAddNote = (pos: Coordinates) => {
   updateStore(store => {
     store.noteTimelines.set(nt.noteId, nt);
   });
-  // TODO push to server. Here?
-  console.log('added note timeline', { nt });
+
+  // FIXME very dirty
+  serverConnection.connection.publishNote({
+    ...(nt.patches[nt.patches.length - 1].diff as Omit<Note, 'id'>),
+    id: nt.noteId
+  });
 };
 
 export const localDeleteNote = (id: Note['id']) => {

--- a/packages/client/src/store/notes.ts
+++ b/packages/client/src/store/notes.ts
@@ -10,6 +10,7 @@ import {
   newCommittedNoteTimeline
 } from './timelines/note';
 
+// TODO change name, if we are doing server push in this function
 export const localAddNote = (pos: Coordinates) => {
   const nt = newLocalNoteTimeline({
     id: v4(),
@@ -20,11 +21,12 @@ export const localAddNote = (pos: Coordinates) => {
     store.noteTimelines.set(nt.noteId, nt);
   });
 
-  // FIXME very dirty
+  // TODO very dirty
   serverConnection.connection.publishNote({
     ...(nt.patches[nt.patches.length - 1].diff as Omit<Note, 'id'>),
     id: nt.noteId
   });
+  // TODO discard Patch from the timeline when server response comes
 };
 
 export const localDeleteNote = (id: Note['id']) => {

--- a/packages/client/src/store/notes.ts
+++ b/packages/client/src/store/notes.ts
@@ -1,10 +1,16 @@
 import { v4 } from 'uuid';
 import { updateStore } from '.';
 import { Coordinates, Note } from '../types';
-import { newNoteTimeline, modifyDelete, modifyText } from './timelines/note';
+import {
+  newLocalNoteTimeline,
+  modifyDelete,
+  modifyText,
+  setCommited,
+  newCommitedNoteTimeline
+} from './timelines/note';
 
-export const addNote = (pos: Coordinates) => {
-  const nt = newNoteTimeline({
+export const localAddNote = (pos: Coordinates) => {
+  const nt = newLocalNoteTimeline({
     id: v4(),
     position: pos,
     text: 'a new note'
@@ -16,7 +22,7 @@ export const addNote = (pos: Coordinates) => {
   console.log('added note timeline', { nt });
 };
 
-export const deleteNote = (id: Note['id']) => {
+export const localDeleteNote = (id: Note['id']) => {
   updateStore(store => {
     const nt = store.noteTimelines.get(id);
     if (!nt) {
@@ -29,7 +35,7 @@ export const deleteNote = (id: Note['id']) => {
   });
 };
 
-export const updateText = (id: Note['id'], newText: string) => {
+export const localUpdateText = (id: Note['id'], newText: string) => {
   updateStore(store => {
     const nt = store.noteTimelines.get(id);
     if (!nt) {
@@ -38,5 +44,22 @@ export const updateText = (id: Note['id'], newText: string) => {
     } else {
       store.noteTimelines.set(nt.noteId, modifyText(nt, newText));
     }
+  });
+};
+
+export const setServerState = (id: Note['id'], state: Note | null) => {
+  updateStore(store => {
+    let nt = store.noteTimelines.get(id);
+    if (!nt) {
+      if (state === null) {
+        // if have nothing to delete
+        return;
+      } else {
+        nt = newCommitedNoteTimeline(state);
+      }
+    } else {
+      nt = setCommited(nt, state);
+    }
+    store.noteTimelines.set(nt.noteId, nt);
   });
 };

--- a/packages/client/src/store/notes.ts
+++ b/packages/client/src/store/notes.ts
@@ -5,8 +5,8 @@ import {
   newLocalNoteTimeline,
   modifyDelete,
   modifyText,
-  setCommited,
-  newCommitedNoteTimeline
+  setCommitted,
+  newCommittedNoteTimeline
 } from './timelines/note';
 
 export const localAddNote = (pos: Coordinates) => {
@@ -55,10 +55,10 @@ export const setServerState = (id: Note['id'], state: Note | null) => {
         // if have nothing to delete
         return;
       } else {
-        nt = newCommitedNoteTimeline(state);
+        nt = newCommittedNoteTimeline(state);
       }
     } else {
-      nt = setCommited(nt, state);
+      nt = setCommitted(nt, state);
     }
     store.noteTimelines.set(nt.noteId, nt);
   });

--- a/packages/client/src/store/notes.ts
+++ b/packages/client/src/store/notes.ts
@@ -1,0 +1,17 @@
+import { v4 } from 'uuid';
+import { updateStore } from '.';
+import { Coordinates } from '../types';
+import { newNoteTimeline } from './timelines/note';
+
+export const addNote = (pos: Coordinates) => {
+  const nt = newNoteTimeline({
+    id: v4(),
+    position: pos,
+    text: 'a new note'
+  });
+  updateStore(store => {
+    store.noteTimelines.set(nt.noteId, nt);
+  });
+  // TODO push to server. Here?
+  console.log('added note timeline', { nt });
+};

--- a/packages/client/src/store/notes.ts
+++ b/packages/client/src/store/notes.ts
@@ -1,7 +1,7 @@
 import { v4 } from 'uuid';
 import { updateStore } from '.';
-import { Coordinates } from '../types';
-import { newNoteTimeline } from './timelines/note';
+import { Coordinates, Note } from '../types';
+import { newNoteTimeline, modifyDelete, modifyText } from './timelines/note';
 
 export const addNote = (pos: Coordinates) => {
   const nt = newNoteTimeline({
@@ -14,4 +14,29 @@ export const addNote = (pos: Coordinates) => {
   });
   // TODO push to server. Here?
   console.log('added note timeline', { nt });
+};
+
+export const deleteNote = (id: Note['id']) => {
+  updateStore(store => {
+    const nt = store.noteTimelines.get(id);
+    if (!nt) {
+      console.error('tried deleting a note without NoteTimeline');
+      return;
+    } else {
+      store.noteTimelines.set(nt.noteId, modifyDelete(nt));
+      console.log('added note removal operation', { nt });
+    }
+  });
+};
+
+export const updateText = (id: Note['id'], newText: string) => {
+  updateStore(store => {
+    const nt = store.noteTimelines.get(id);
+    if (!nt) {
+      console.error('tried updating text of a note without NoteTimeline');
+      return;
+    } else {
+      store.noteTimelines.set(nt.noteId, modifyText(nt, newText));
+    }
+  });
 };

--- a/packages/client/src/store/timelines/note.ts
+++ b/packages/client/src/store/timelines/note.ts
@@ -1,7 +1,9 @@
 import { v4 } from 'uuid';
 import type { Note, Coordinates, UUID } from '../../types';
 
-type Diff = Partial<Omit<Note, 'id'>>;
+// TODO functions below should probably validate
+// that after 'deleted' there can't be newer patches
+type Diff = Partial<Omit<Note, 'id'>> | 'deleted';
 
 type Patch = {
   changeId: UUID;
@@ -29,6 +31,9 @@ export const getNewestLocalState = (nt: NoteTimeline): Note | null => {
   }
 
   for (const diff of patchesReverse) {
+    if (diff === 'deleted') {
+      return null;
+    }
     if (diff.position !== undefined && current.position === undefined) {
       current.position = diff.position;
     }
@@ -65,6 +70,11 @@ export const modifyPositiion = (
     patches: nt.patches.concat(newPatch({ position: newPosition }))
   };
 };
+
+export const modifyDelete = (nt: NoteTimeline): NoteTimeline => ({
+  ...nt,
+  patches: nt.patches.concat(newPatch('deleted'))
+});
 
 export const setCommited = (
   nt: NoteTimeline,

--- a/packages/client/src/store/timelines/note.ts
+++ b/packages/client/src/store/timelines/note.ts
@@ -48,7 +48,13 @@ export const getNewestLocalState = (nt: NoteTimeline): Note | null => {
   return null;
 };
 
-export const newNoteTimeline = (initial: Note): NoteTimeline => ({
+export const newCommitedNoteTimeline = (initial: Note): NoteTimeline => ({
+  noteId: initial.id,
+  commited: initial,
+  patches: []
+});
+
+export const newLocalNoteTimeline = (initial: Note): NoteTimeline => ({
   noteId: initial.id,
   commited: null,
   patches: [newPatch(initial)]

--- a/packages/client/src/store/timelines/note.ts
+++ b/packages/client/src/store/timelines/note.ts
@@ -12,7 +12,7 @@ type Patch = {
 
 export type NoteTimeline = {
   noteId: UUID;
-  commited: Note | null;
+  committed: Note | null;
   patches: Patch[];
 };
 
@@ -26,8 +26,8 @@ export const getNewestLocalState = (nt: NoteTimeline): Note | null => {
 
   const current: Partial<Note> = { id: nt.noteId };
   const patchesReverse = [...nt.patches.map(p => p.diff)].reverse();
-  if (nt.commited) {
-    patchesReverse.push(nt.commited); // lowest priority
+  if (nt.committed) {
+    patchesReverse.push(nt.committed); // lowest priority
   }
 
   for (const diff of patchesReverse) {
@@ -48,15 +48,15 @@ export const getNewestLocalState = (nt: NoteTimeline): Note | null => {
   return null;
 };
 
-export const newCommitedNoteTimeline = (initial: Note): NoteTimeline => ({
+export const newCommittedNoteTimeline = (initial: Note): NoteTimeline => ({
   noteId: initial.id,
-  commited: initial,
+  committed: initial,
   patches: []
 });
 
 export const newLocalNoteTimeline = (initial: Note): NoteTimeline => ({
   noteId: initial.id,
-  commited: null,
+  committed: null,
   patches: [newPatch(initial)]
 });
 
@@ -82,12 +82,12 @@ export const modifyDelete = (nt: NoteTimeline): NoteTimeline => ({
   patches: nt.patches.concat(newPatch('deleted'))
 });
 
-export const setCommited = (
+export const setCommitted = (
   nt: NoteTimeline,
-  commited: NoteTimeline['commited']
+  committed: NoteTimeline['committed']
 ): NoteTimeline => ({
   ...nt,
-  commited
+  committed
 });
 
 export const discardPatch = (

--- a/packages/client/src/store/timelines/note.ts
+++ b/packages/client/src/store/timelines/note.ts
@@ -1,5 +1,5 @@
 import { v4 } from 'uuid';
-import type { Note, Coordinates, UUID } from '../types';
+import type { Note, Coordinates, UUID } from '../../types';
 
 type Diff = Partial<Omit<Note, 'id'>>;
 

--- a/packages/client/src/types.ts
+++ b/packages/client/src/types.ts
@@ -1,6 +1,11 @@
-import { v4 as uuidv4, v4 } from 'uuid';
+import { v4 as uuidv4 } from 'uuid';
+import { Coordinates } from './protocol/protocol';
+
+export type { Coordinates } from './protocol/protocol';
 
 export type UUID = ReturnType<typeof uuidv4>;
+
+export type MessageId = UUID;
 
 export type Mode = 'draw' | 'erase' | 'note';
 
@@ -11,28 +16,23 @@ export type Action =
     }
   | {
       type: 'erase';
-      lines: Map<UUID, Coordinate[]>;
+      lines: Map<UUID, Coordinates[]>;
     };
-
-export type Coordinate = {
-  x: number;
-  y: number;
-};
 
 export type Line = {
   UUID: UUID;
-  points: Map<Coordinate, number>;
+  points: Map<Coordinates, number>;
 };
 
 export type Note = {
   UUID: UUID;
-  position: Coordinate;
+  position: Coordinates;
   text: string;
 };
 
 export type Img = {
   UUID: UUID;
-  position: Coordinate;
+  position: Coordinates;
   data: string; // ts img object?
 };
 
@@ -51,7 +51,7 @@ export enum MessageCode {
 
 export type Figure = {
   type: 'Note';
-  location: Coordinate;
+  location: Coordinates;
 };
 
 export class CreateWhiteboardMsg {

--- a/packages/client/src/utils.ts
+++ b/packages/client/src/utils.ts
@@ -1,0 +1,9 @@
+export function isNotNullsih<TValue>(
+  value: TValue | null | undefined
+): value is TValue {
+  /** A type predicate */
+  return value !== null && value !== undefined;
+}
+
+export const removeNullish = <T>(array: (T | null | undefined)[]): T[] =>
+  array.filter(isNotNullsih);

--- a/protocol/protocol.proto
+++ b/protocol/protocol.proto
@@ -15,8 +15,8 @@ message Note {
   /* UUID in byte representation. Saves bandwidth, but more
      problematic in code */
   bytes id = 1;
-  Coordinates coordinates = 2;
-  string content = 3;
+  Coordinates position = 2;
+  string text = 3;
 }
 
 message BitmapPoint {
@@ -61,8 +61,14 @@ message UpdateNote { Note note = 1; }
 message DeleteNote { Note note = 1; }
 
 // broadcasted to all
-message NoteCreatedOrUpdated { Note note = 1; }
-message NoteDeleted { bytes note_id = 1; }
+message NoteCreatedOrUpdated {
+  Note note = 1;
+  string triggered_by = 2;
+}
+message NoteDeleted {
+  bytes note_id = 1;
+  string triggered_by = 2;
+}
 
 message ResultError {
   string triggered_by = 1; // message id

--- a/protocol/protocol.proto
+++ b/protocol/protocol.proto
@@ -56,6 +56,22 @@ enum ErrorReason {
   WHITEBOARD_DOES_NOT_EXIST = 1;
 }
 
+message CreateNote {
+  string change_id = 1;
+  Note note = 2;
+}
+
+message CreateNoteError {
+  string change_id = 1;
+  ErrorReason reason = 2;
+}
+
+// broadcasted to all
+message NoteCreatedOrUpdated {
+  string change_id = 1; // used by creator to discard local state
+  Note note = 2;
+}
+
 message ResultError { ErrorReason reason = 1; }
 message ResultSuccess {}
 
@@ -66,6 +82,7 @@ message ClientToServerMessage {
     JoinWhiteboard join_whiteboard = 3;
     MoveFigure move_figure = 5;
     Line line_drawn = 6;
+    CreateNote create_note = 7;
   }
 }
 
@@ -77,5 +94,7 @@ message ServerToClientMessage {
     GetAllFiguresResponse get_all_figures_response = 4;
     FigureMoved figure_moved = 5;
     Line line_drawn = 6;
+    CreateNoteError create_note_error = 7;
+    NoteCreatedOrUpdated note_created_or_updated = 8;
   }
 }

--- a/protocol/protocol.proto
+++ b/protocol/protocol.proto
@@ -56,26 +56,24 @@ enum ErrorReason {
   WHITEBOARD_DOES_NOT_EXIST = 1;
 }
 
-message CreateNote {
-  string change_id = 1;
-  Note note = 2;
-}
-
-message CreateNoteError {
-  string change_id = 1;
-  ErrorReason reason = 2;
-}
+message CreateNote { Note note = 1; }
+message UpdateNote { Note note = 1; }
+message DeleteNote { Note note = 1; }
 
 // broadcasted to all
-message NoteCreatedOrUpdated {
-  string change_id = 1; // used by creator to discard local state
-  Note note = 2;
+message NoteCreatedOrUpdated { Note note = 1; }
+message NoteDeleted { bytes note_id = 1; }
+
+message ResultError {
+  string triggered_by = 1; // message id
+  ErrorReason reason = 2;
+}
+message ResultSuccess {
+  string triggered_by = 1; // message id
 }
 
-message ResultError { ErrorReason reason = 1; }
-message ResultSuccess {}
-
 message ClientToServerMessage {
+  string messsage_id = 100;
   oneof body {
     CreateWhiteboardRequest create_whiteboard_request = 1;
     GetAllFiguresRequest get_all_figures_request = 2;
@@ -87,6 +85,7 @@ message ClientToServerMessage {
 }
 
 message ServerToClientMessage {
+  string messsage_id = 100;
   oneof body {
     ResultError error = 1;
     ResultSuccess success = 2;
@@ -94,7 +93,6 @@ message ServerToClientMessage {
     GetAllFiguresResponse get_all_figures_response = 4;
     FigureMoved figure_moved = 5;
     Line line_drawn = 6;
-    CreateNoteError create_note_error = 7;
     NoteCreatedOrUpdated note_created_or_updated = 8;
   }
 }


### PR DESCRIPTION
The main focus of these changes is organizing data storage on the frontend, so that:
- it can play nicely with React, that is trigger rerenders when necessary
- it has distinct storage for localy made changes, which wait for server's ACK but influence what the local user sees, and globally accepted changes (i.e., corresponding to server-side state)

The most interesting code for the is in `/packages/client/src/store`
The general idea is to store information in "Timeline" objects, e.g., `NoteTimeline`. Such object contains 'committed' state (known to be accepted by the server; includes changes of remote users) and a list of Patches which modify the committed state and are known only locally.

There is a function `getCombinedState` that gathers all those partial changes and presents them as simple `Note` objects, which is what the local Editor needs to display. React rerender is ensured by inserting this simplifid state into a setState callback of `useState`. This is done in the `useGlobalStore` hook, currently invoked in Editor.

Note that currently local changes waiting for approval or rejection take precedence in displaying over any changes comming from server. I think it is not a huge problem, since the server response should come pretty soon, and be either:
- acceptance of the changes, in which the display does not change, as it already contained the correct state
- rejection, in which case we discard the Patch and the committed state containing other users' changes is revealed

After a server processes an update, it should respond with either an errror message, or a multicast informing all clients of the new state. Upon receiving any of those, the client that made the edit should discard the corresponding Patch, since the changes are incorporated in the new 'commited' state. I didn't get to implementing that yet, I image doing some event subscriptions on the ServerConnection for subscriving for specific message id (server messages now include the id of a client message that caused some operation).