### PR TITLE
Separate encoding to package

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "protoc": "concurrently \"yarn protoc:client\" \"yarn protoc:server\"",
     "start:client": "cd packages/client && yarn start",
     "start:server": "cd packages/backend && yarn dev",
-    "start:dev": "concurrently \"yarn start:client\" \"yarn start:server\""
+    "watch:encoding": "cd packages/encoding && yarn watch",
+    "start:dev": "concurrently \"yarn start:client\" \"yarn start:server\" \"yarn watch:encoding\""
   },
   "devDependencies": {
     "concurrently": "^6.0.0",

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -27,6 +27,7 @@
   },
   "dependencies": {
     "@types/uuid": "^8.3.0",
+    "encoding": "^0.0.0",
     "express": "^4.17.1",
     "tiny-typed-emitter": "^2.0.3",
     "uuid": "^8.3.2",

--- a/packages/backend/src/controllers/pre-whiteboard-controller.ts
+++ b/packages/backend/src/controllers/pre-whiteboard-controller.ts
@@ -1,4 +1,5 @@
-import { decodeUUID, makeErrorMessage, resultToMessage } from '../encoding';
+import { makeErrorMessage, resultToMessage } from '../encoding';
+import { decodeUUID } from 'encoding';
 import { ClientConnection } from '../models/client-connection';
 import { addWhiteboard, connectClient } from '../models/whiteboard';
 import { ClientToServerMessage, ErrorReason } from '../protocol/protocol';

--- a/packages/backend/src/controllers/whiteboard-controller.ts
+++ b/packages/backend/src/controllers/whiteboard-controller.ts
@@ -1,9 +1,5 @@
-import {
-  decodeUUID,
-  makeErrorMessage,
-  messageToLine,
-  messageToNote
-} from '../encoding';
+import { makeErrorMessage, messageToLine, messageToNote } from '../encoding';
+import { decodeUUID } from 'encoding';
 import { ClientConnection } from '../models/client-connection';
 import { OperationType } from '../models/whiteboard';
 import { ClientToServerMessage, ErrorReason } from '../protocol/protocol';

--- a/packages/backend/src/encoding.ts
+++ b/packages/backend/src/encoding.ts
@@ -8,6 +8,7 @@ import {
   ClientToServerMessage
 } from './protocol/protocol';
 import type { Result, UUID } from './types';
+import { decodeUUID } from 'encoding';
 
 export type ClientToServerCase = NonNullable<
   ClientToServerMessage['body']
@@ -15,8 +16,6 @@ export type ClientToServerCase = NonNullable<
 
 export const encodeUUID = (id: UUID): Uint8Array =>
   Uint8Array.from(uuid.parse(id));
-
-export const decodeUUID = (id: Uint8Array): UUID => uuid.stringify(id);
 
 export const resultToMessage = (
   result: Result

--- a/packages/backend/src/encoding.ts
+++ b/packages/backend/src/encoding.ts
@@ -14,9 +14,6 @@ export type ClientToServerCase = NonNullable<
   ClientToServerMessage['body']
 >['$case'];
 
-export const encodeUUID = (id: UUID): Uint8Array =>
-  Uint8Array.from(uuid.parse(id));
-
 export const resultToMessage = (
   result: Result
 ): ServerToClientMessage['body'] => {

--- a/packages/backend/src/models/whiteboard.ts
+++ b/packages/backend/src/models/whiteboard.ts
@@ -1,10 +1,6 @@
 import { v4 as uuidv4 } from 'uuid';
-import {
-  encodeUUID,
-  encodeUUID as uuidStringToBytes,
-  noteToMessage,
-  resultToMessage
-} from '../encoding';
+import { noteToMessage, resultToMessage } from '../encoding';
+import { encodeUUID } from 'encoding';
 import {
   ClientToServerMessage,
   Coordinates,
@@ -111,7 +107,7 @@ export class Whiteboard {
       //   this.sendToClients({
       //     $case: 'figureMoved',
       //     figureMoved: {
-      //       figureId: uuidStringToBytes(figure.id),
+      //       figureId: encodeUUID(figure.id),
       //       newCoordinates: newCoords
       //     }
       //   });

--- a/packages/backend/src/tests/server.test.ts
+++ b/packages/backend/src/tests/server.test.ts
@@ -7,7 +7,7 @@ import {
   ClientToServerMessage
 } from '../protocol/protocol';
 import { v4 } from 'uuid';
-import { encodeUUID } from '../encoding';
+import { encodeUUID } from 'encoding';
 
 describe('WebSockeet server', () => {
   beforeEach(done => {

--- a/packages/backend/tsconfig.json
+++ b/packages/backend/tsconfig.json
@@ -1,1 +1,3 @@
-../../tsconfig.json
+{
+  "extends": "../../tsconfig.json"
+}

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -15,6 +15,7 @@
     "@types/react-dom": "^17.0.0",
     "@types/react-native": "^0.63.49",
     "@types/uuid": "^8.3.0",
+    "encoding": "^0.0.0",
     "react": "^17.0.1",
     "react-art": "^17.0.1",
     "react-dom": "^17.0.1",

--- a/packages/client/src/connection/incoming-handler.ts
+++ b/packages/client/src/connection/incoming-handler.ts
@@ -1,4 +1,4 @@
-import { decodeUUID } from '../editor/encoding';
+import { decodeUUID } from 'encoding';
 import * as whiteboard from '../editor/whiteboard';
 import { ServerToClientMessage } from '../protocol/protocol';
 import { setServerState } from '../store/notes';

--- a/packages/client/src/editor/encoding.ts
+++ b/packages/client/src/editor/encoding.ts
@@ -1,7 +1,0 @@
-import * as uuid from 'uuid';
-import type { UUID } from '../types';
-
-export const encodeUUID = (id: UUID): Uint8Array =>
-  Uint8Array.from(uuid.parse(id));
-
-export const decodeUUID = (id: Uint8Array): UUID => uuid.stringify(id);

--- a/packages/encoding/lib/encoding.ts
+++ b/packages/encoding/lib/encoding.ts
@@ -1,0 +1,9 @@
+import * as uuid from 'uuid';
+import type { v4 as uuidv4 } from 'uuid';
+
+export type UUID = ReturnType<typeof uuidv4>;
+
+export const encodeUUID = (id: UUID): Uint8Array =>
+  Uint8Array.from(uuid.parse(id));
+
+export const decodeUUID = (id: Uint8Array): UUID => uuid.stringify(id);

--- a/packages/encoding/nodemon.json
+++ b/packages/encoding/nodemon.json
@@ -1,0 +1,6 @@
+{
+  "watch": ["lib", "package.json"],
+  "ext": ".ts,.js",
+  "ignore": [],
+  "exec": "yarn build"
+}

--- a/packages/encoding/package.json
+++ b/packages/encoding/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "encoding",
+  "version": "0.0.0",
+  "description": "",
+  "author": "",
+  "homepage": "https://github.com/wgslr/trunkless-whiteboard#readme",
+  "main": "dist/encoding.js",
+  "directories": {
+    "lib": "lib"
+  },
+  "files": [
+    "lib"
+  ],
+  "publishConfig": {
+    "registry": "https://registry.yarnpkg.com"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/wgslr/trunkless-whiteboard.git"
+  },
+  "scripts": {
+    "test": "echo \"Error: run tests from root\" && exit 1",
+    "clean": "rm --recursive --force dist",
+    "build": "yarn run clean && tsc -p tsconfig.json",
+    "watch": "nodemon"
+  },
+  "dependencies": {
+    "uuid": "^8.3.2"
+  },
+  "devDependencies": {
+    "@types/node": "^14.14.34",
+    "@types/uuid": "^8.3.0",
+    "typescript": "^4.2.3"
+  }
+}

--- a/packages/encoding/tsconfig.json
+++ b/packages/encoding/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "declaration": true,
+    "typeRoots": [
+      "./lib"
+    ]
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3118,6 +3118,11 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-13.13.46.tgz#5471e176f3fa15e018dea7992072bf8ca208a3a6"
   integrity sha512-dqpbzK/KDsOlEt+oyB3rv+u1IxlLFziZu/Z0adfRKoelkr+sTd6QcgiQC+HWq/vkYkHwG5ot2LxgV05aAjnhcg==
 
+"@types/node@^14.14.34":
+  version "14.14.34"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.14.34.tgz#07935194fc049069a1c56c0c274265abeddf88da"
+  integrity sha512-dBPaxocOK6UVyvhbnpFIj2W+S+1cBTkHQbFQfeeJhoKFbzYcVUGHvddeWPSucKATb3F0+pgDq0i6ghEaZjsugA==
+
 "@types/normalize-package-data@^2.4.0":
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz#e486d0d97396d79beedd0a6e33f4534ff6b4973e"
@@ -15703,7 +15708,7 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@^4.1.2, typescript@^4.1.5:
+typescript@^4.1.2, typescript@^4.1.5, typescript@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.2.3.tgz#39062d8019912d43726298f09493d598048c1ce3"
   integrity sha512-qOcYwxaByStAWrBf4x0fibwZvMRG+r4cQoTjbPtUlrWjBHbmCAww1i448U0GJ+3cNNEtebDteo/cHOR3xJ4wEw==


### PR DESCRIPTION
This creates a new package name `encoding`, which should be the default package for handling everything with encoding/decoding protobufs in other packages.

The PR also cleans up the `tsconfig.json` files we have scattered around.