### PR TITLE
Line global store, no valtio

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 *.swp
 packages/*/src/protocol/
 
+# flame graphs
+.clinic
+
 ## Taken from here:
 # https://github.com/github/gitignore/blob/master/Node.gitignore
 

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -18,6 +18,7 @@
     "@types/express": "^4.17.11",
     "@types/jest": "^26.0.20",
     "@types/node": "^14.14.28",
+    "@types/ramda": "^0.27.39",
     "@types/ws": "^7.4.0",
     "nodemon": "^2.0.7",
     "superwstest": "^1.3.0",
@@ -29,6 +30,7 @@
     "@types/uuid": "^8.3.0",
     "encoding": "^0.0.0",
     "express": "^4.17.1",
+    "ramda": "^0.27.1",
     "tiny-typed-emitter": "^2.0.3",
     "uuid": "^8.3.2",
     "ws": "^7.4.3"

--- a/packages/backend/src/controllers/allowed-messages.ts
+++ b/packages/backend/src/controllers/allowed-messages.ts
@@ -5,6 +5,7 @@ const commonWhitboardMessages: ClientToServerCase[] = [
   'createNote',
   'deleteNote',
   'createLine',
+  'addPointsToLine',
   'updateNotePosition',
   'updateNoteText'
 ];

--- a/packages/backend/src/controllers/allowed-messages.ts
+++ b/packages/backend/src/controllers/allowed-messages.ts
@@ -4,7 +4,7 @@ import { WhiteboardMembership } from '../models/client-connection';
 const commonWhitboardMessages: ClientToServerCase[] = [
   'createNote',
   'deleteNote',
-  'lineDrawn',
+  'createLine',
   'updateNotePosition',
   'updateNoteText'
 ];

--- a/packages/backend/src/controllers/whiteboard-controller.ts
+++ b/packages/backend/src/controllers/whiteboard-controller.ts
@@ -21,7 +21,6 @@ export const handleWhiteboardMessage = (
     case 'createLine': {
       const data = message.body.createLine;
       const decodedData = messageToLine(data.line!);
-      console.log(`Line drawn`, decodedData);
 
       whiteboard.handleOperation(
         {

--- a/packages/backend/src/controllers/whiteboard-controller.ts
+++ b/packages/backend/src/controllers/whiteboard-controller.ts
@@ -18,15 +18,28 @@ export const handleWhiteboardMessage = (
   const whiteboard = client.status.whiteboard;
 
   switch (message.body.$case) {
-    case 'lineDrawn': {
-      const data = message.body.lineDrawn;
-      const decodedData = messageToLine(data);
+    case 'createLine': {
+      const data = message.body.createLine;
+      const decodedData = messageToLine(data.line!);
       console.log(`Line drawn`, decodedData);
 
       whiteboard.handleOperation(
         {
-          type: OperationType.LINE_ADD,
-          data: { line: decodedData }
+          type: OperationType.LINE_CREATE,
+          data: { line: decodedData, causedBy: message.messsageId }
+        },
+        client
+      );
+      return;
+    }
+    case 'addPointsToLine': {
+      const { lineId: idRaw, points } = message.body.addPointsToLine;
+      const id = decodeUUID(idRaw);
+
+      whiteboard.handleOperation(
+        {
+          type: OperationType.LINE_ADD_POINTS,
+          data: { causedBy: message.messsageId, change: { id, points } }
         },
         client
       );

--- a/packages/backend/src/encoding.ts
+++ b/packages/backend/src/encoding.ts
@@ -1,7 +1,7 @@
 import * as uuid from 'uuid';
-import { Note } from './models/whiteboard';
+import { Note, Line } from './models/whiteboard';
 import {
-  Line,
+  Line as LineProto,
   ServerToClientMessage,
   Note as NoteProto,
   ErrorReason,
@@ -34,12 +34,10 @@ export const makeErrorMessage = (
   error: { reason }
 });
 
-export const messageToLine = (data: Line) => {
-  return {
-    id: decodeUUID(data.id),
-    bitmap: new Map(data.bitmap.map(point => [point.coordinates!, point.value]))
-  };
-};
+export const messageToLine = (data: LineProto): Line => ({
+  id: decodeUUID(data.id),
+  points: data.points
+});
 
 export const noteToMessage = (note: Note): NoteProto => ({
   ...note,

--- a/packages/backend/src/models/client-connection.ts
+++ b/packages/backend/src/models/client-connection.ts
@@ -70,8 +70,9 @@ export class ClientConnection extends TypedEmitter<ClientConnectionEvents> {
       // const decoded = decodeMessage(message as string);
       let decoded;
       try {
+        console.debug(`Decoding message`);
         decoded = ClientToServerMessage.decode(Reader.create(message));
-        console.debug(`Received messaeg:`, { decoded });
+        console.debug(`Decoded message:`, { decoded });
       } catch (error) {
         console.error('Error decoding message', error);
         return;

--- a/packages/backend/src/models/client-connection.ts
+++ b/packages/backend/src/models/client-connection.ts
@@ -70,11 +70,10 @@ export class ClientConnection extends TypedEmitter<ClientConnectionEvents> {
       // const decoded = decodeMessage(message as string);
       let decoded;
       try {
-        console.debug(`Decoding message`);
         decoded = ClientToServerMessage.decode(Reader.create(message));
-        console.debug(`Decoded message:`, { decoded });
+        console.debug(`Decoded message:`, decoded.body?.$case);
       } catch (error) {
-        console.error('Error decoding message', error);
+        console.warn('Error decoding message', error);
         return;
       }
       this.emit('message', decoded);

--- a/packages/backend/src/models/whiteboard.ts
+++ b/packages/backend/src/models/whiteboard.ts
@@ -109,8 +109,6 @@ export class Whiteboard {
         };
         this.lines.set(line.id, sanitizedLine);
 
-        console.log(`There are ${this.lines.size} lines on the whiteboard`);
-
         this.sendToClients(
           {
             $case: 'lineCreatedOrUpdated',
@@ -170,7 +168,6 @@ export class Whiteboard {
           );
         } else {
           this.notes.set(note.id, note);
-          console.log('Added note', note);
           this.sendToClients(
             {
               $case: 'noteCreatedOrUpdated',
@@ -213,7 +210,6 @@ export class Whiteboard {
         };
 
         this.notes.set(note.id, updated);
-        console.log('Updated note', { old: note, updated });
         this.sendToClients(
           {
             $case: 'noteCreatedOrUpdated',
@@ -265,7 +261,6 @@ export class Whiteboard {
   }
 
   private areCoordsWithinBounds(coords: Coordinates): boolean {
-    console.log(coords);
     return (
       coords.x >= 0 &&
       coords.x <= this.MAX_WIDTH &&
@@ -278,7 +273,10 @@ export class Whiteboard {
     message: ServerToClientMessage['body'],
     previousMessageId?: string
   ) {
-    console.log(`Sending message to ${this.clients.length} clients:`, message);
+    console.debug(
+      `Sending message to ${this.clients.length} clients:`,
+      message?.$case
+    );
     this.clients.forEach(client => {
       client.send(message, previousMessageId);
     });
@@ -318,7 +316,3 @@ export const connectClient = (
     return { result: 'success' };
   }
 };
-
-// setInterval(() => {
-//   console.log(`There are ${countWhiteboards()} whiteboards`, whiteboards);
-// }, 2000);

--- a/packages/backend/src/models/whiteboard.ts
+++ b/packages/backend/src/models/whiteboard.ts
@@ -1,6 +1,6 @@
+import { encodeUUID } from 'encoding';
 import { v4 as uuidv4 } from 'uuid';
 import { noteToMessage, resultToMessage } from '../encoding';
-import { encodeUUID } from 'encoding';
 import {
   ClientToServerMessage,
   Coordinates,
@@ -10,7 +10,6 @@ import {
 } from '../protocol/protocol';
 import { Result, UUID } from '../types';
 import { ClientConnection } from './client-connection';
-import * as R from 'ramda';
 
 export abstract class Figure {
   id: UUID;
@@ -106,7 +105,7 @@ export class Whiteboard {
         const { line, causedBy } = op.data;
         const sanitizedLine = {
           id: line.id,
-          points: this.removeInvalidCoords(R.uniq(line.points))
+          points: this.removeInvalidCoords(line.points)
         };
         this.lines.set(line.id, sanitizedLine);
 
@@ -140,8 +139,7 @@ export class Whiteboard {
           return;
         }
 
-        line.points = R.union(
-          line.points,
+        line.points = line.points.concat(
           this.removeInvalidCoords(patch.points)
         );
 

--- a/packages/backend/src/models/whiteboard.ts
+++ b/packages/backend/src/models/whiteboard.ts
@@ -104,10 +104,11 @@ export class Whiteboard {
     switch (op.type) {
       case OperationType.LINE_CREATE: {
         const { line, causedBy } = op.data;
-        this.lines.set(line.id, {
+        const sanitizedLine = {
           id: line.id,
-          points: R.uniq(line.points)
-        });
+          points: this.removeInvalidCoords(R.uniq(line.points))
+        };
+        this.lines.set(line.id, sanitizedLine);
 
         console.log(`There are ${this.lines.size} lines on the whiteboard`);
 
@@ -116,8 +117,8 @@ export class Whiteboard {
             $case: 'lineCreatedOrUpdated',
             lineCreatedOrUpdated: {
               line: {
-                id: encodeUUID(line.id),
-                points: this.removeInvalidCoords(line.points)
+                id: encodeUUID(sanitizedLine.id),
+                points: sanitizedLine.points
               }
             }
           },

--- a/packages/backend/src/models/whiteboard.ts
+++ b/packages/backend/src/models/whiteboard.ts
@@ -261,6 +261,7 @@ export class Whiteboard {
   }
 
   private removeInvalidCoords(coordList: Coordinates[]): Coordinates[] {
+    return coordList;
     return coordList.filter(c => this.areCoordsWithinBounds(c));
   }
 

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -16,6 +16,7 @@
     "@types/react-native": "^0.63.49",
     "@types/uuid": "^8.3.0",
     "encoding": "^0.0.0",
+    "ramda": "^0.27.1",
     "react": "^17.0.1",
     "react-art": "^17.0.1",
     "react-dom": "^17.0.1",
@@ -57,6 +58,7 @@
     ]
   },
   "devDependencies": {
+    "@types/ramda": "^0.27.39",
     "@types/uuid": "^8.3.0",
     "@types/ws": "^7.4.0"
   }

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -16,6 +16,7 @@
     "@types/react-native": "^0.63.49",
     "@types/uuid": "^8.3.0",
     "encoding": "^0.0.0",
+    "just-debounce": "^1.1.0",
     "ramda": "^0.27.1",
     "react": "^17.0.1",
     "react-art": "^17.0.1",

--- a/packages/client/src/config.ts
+++ b/packages/client/src/config.ts
@@ -1,5 +1,5 @@
 /** After this time we stop looking for response among incoming messages */
-export const SERVER_RESPONSE_TIMEOUT = 5000;
+export const SERVER_RESPONSE_TIMEOUT = 10_000;
 
 // TODO: set as env variable
 export const SERVER_URL = 'ws://localhost:3001/ws';

--- a/packages/client/src/connection/incoming-handler.ts
+++ b/packages/client/src/connection/incoming-handler.ts
@@ -1,28 +1,27 @@
 import { decodeUUID } from 'encoding';
 import * as whiteboard from '../editor/whiteboard';
 import { ServerToClientMessage } from '../protocol/protocol';
-import { setServerState } from '../store/notes';
+import * as notesStore from '../store/notes';
+import * as linesStore from '../store/lines';
 import { decodeLineData, messageToNote } from './messages';
 
 export const handleMessage = (message: ServerToClientMessage): void => {
-  // console.log(`Received message: ${message.body?.$case}`);
-  // console.debug(`Received message body:`, message.body);
+  console.log(`Received message: ${message.body?.$case}`);
+  console.debug(`Received message body:`, message.body);
   switch (message.body?.$case) {
-    case 'lineDrawn': {
-      const lineData = decodeLineData(message.body.lineDrawn);
-      // TODO encapsulate it in the whiteboard module
-      // TODO ignore on the client that created the line
-      // whiteboard.lines.push({ id: lineData.id, points: lineData.points });
+    case 'lineCreatedOrUpdated': {
+      const lineData = decodeLineData(message.body.lineCreatedOrUpdated.line!);
+      linesStore.setServerState(lineData.id, lineData);
       break;
     }
     case 'noteCreatedOrUpdated': {
       const noteData = messageToNote(message.body.noteCreatedOrUpdated.note!);
-      setServerState(noteData.id, noteData);
+      notesStore.setServerState(noteData.id, noteData);
       break;
     }
     case 'noteDeleted': {
       const id = decodeUUID(message.body.noteDeleted.noteId);
-      setServerState(id, null);
+      notesStore.setServerState(id, null);
     }
   }
 };

--- a/packages/client/src/connection/incoming-handler.ts
+++ b/packages/client/src/connection/incoming-handler.ts
@@ -12,7 +12,7 @@ export const handleMessage = (message: ServerToClientMessage): void => {
       const lineData = decodeLineData(message.body.lineDrawn);
       // TODO encapsulate it in the whiteboard module
       // TODO ignore on the client that created the line
-      whiteboard.lines.push({ UUID: lineData.UUID, points: lineData.points });
+      whiteboard.lines.push({ id: lineData.id, points: lineData.points });
       break;
     }
     case 'noteCreatedOrUpdated': {

--- a/packages/client/src/connection/incoming-handler.ts
+++ b/packages/client/src/connection/incoming-handler.ts
@@ -12,7 +12,7 @@ export const handleMessage = (message: ServerToClientMessage): void => {
       const lineData = decodeLineData(message.body.lineDrawn);
       // TODO encapsulate it in the whiteboard module
       // TODO ignore on the client that created the line
-      whiteboard.lines.push({ id: lineData.id, points: lineData.points });
+      // whiteboard.lines.push({ id: lineData.id, points: lineData.points });
       break;
     }
     case 'noteCreatedOrUpdated': {

--- a/packages/client/src/connection/incoming-handler.ts
+++ b/packages/client/src/connection/incoming-handler.ts
@@ -5,8 +5,8 @@ import { setServerState } from '../store/notes';
 import { decodeLineData, messageToNote } from './messages';
 
 export const handleMessage = (message: ServerToClientMessage): void => {
-  console.log(`Received message: ${message.body?.$case}`);
-  console.debug(`Received message body:`, message.body);
+  // console.log(`Received message: ${message.body?.$case}`);
+  // console.debug(`Received message body:`, message.body);
   switch (message.body?.$case) {
     case 'lineDrawn': {
       const lineData = decodeLineData(message.body.lineDrawn);

--- a/packages/client/src/connection/messages.ts
+++ b/packages/client/src/connection/messages.ts
@@ -9,7 +9,7 @@ import { Line } from '../types';
 import { Line as LineProto } from '../protocol/protocol';
 
 export function lineToMessage(line: Line): ClientToServerMessage['body'] {
-  const id = encodeUUID(line.UUID);
+  const id = encodeUUID(line.id);
   const lineDrawn = {
     id,
     bitmap: [...line.points].map(entry => ({
@@ -63,7 +63,7 @@ export function decodeLineData(data: LineProto): Line {
     });
 
   return {
-    UUID: decodeUUID(data.id),
+    id: decodeUUID(data.id),
     points
   };
 }

--- a/packages/client/src/connection/messages.ts
+++ b/packages/client/src/connection/messages.ts
@@ -1,12 +1,10 @@
 import * as uuid from 'uuid';
 import {
   ClientToServerMessage,
-  Coordinates,
+  Line as LineProto,
   Note as NoteProto
 } from '../protocol/protocol';
-import type { Note, UUID } from '../types';
-import { Line } from '../types';
-import { Line as LineProto } from '../protocol/protocol';
+import type { Line, Note, UUID } from '../types';
 
 export function lineToMessage(line: Line): ClientToServerMessage['body'] {
   const id = encodeUUID(line.id);
@@ -46,6 +44,13 @@ export const makeDeleteNoteMessage = (
 ): ClientToServerMessage['body'] => ({
   $case: 'deleteNote',
   deleteNote: { noteId: encodeUUID(id) }
+});
+
+export const makeCreateLineMessage = (
+  line: Line
+): ClientToServerMessage['body'] => ({
+  $case: 'createLine',
+  createLine: {}
 });
 
 // TODO deduplciate with backend code

--- a/packages/client/src/connection/messages.ts
+++ b/packages/client/src/connection/messages.ts
@@ -54,13 +54,7 @@ const encodeUUID = (id: UUID): Uint8Array => Uint8Array.from(uuid.parse(id));
 const decodeUUID = (id: Uint8Array): UUID => uuid.stringify(id);
 
 export function decodeLineData(data: LineProto): Line {
-  const points = new Set<Coordinates>();
-  data.bitmap
-    .filter(p => p.value == 1)
-    .forEach(point => {
-      // undefined should not be possible, but typing complains
-      point.coordinates !== undefined && points.add(point.coordinates);
-    });
+  const points = data.bitmap.filter(p => p.value == 1).map(p => p.coordinates!);
 
   return {
     id: decodeUUID(data.id),

--- a/packages/client/src/connection/protobuf-client.ts
+++ b/packages/client/src/connection/protobuf-client.ts
@@ -29,8 +29,6 @@ export class ProtobufSocketClient extends TypedEmitter<Events> {
     this.socket.addEventListener('close', () => {
       this.emit('disconnect');
     });
-
-    this.addListener('message', msg => console.debug('Reeived message', msg));
   }
 
   public send(message: ClientToServerMessage) {

--- a/packages/client/src/connection/protobuf-client.ts
+++ b/packages/client/src/connection/protobuf-client.ts
@@ -32,7 +32,10 @@ export class ProtobufSocketClient extends TypedEmitter<Events> {
   }
 
   public send(message: ClientToServerMessage) {
-    this.socket.send(encode(message));
+    console.log(performance.now(), 'encoding message');
+    const encoded = encode(message);
+    console.log(performance.now(), 'sending message');
+    this.socket.send(encoded);
   }
 }
 

--- a/packages/client/src/connection/protobuf-client.ts
+++ b/packages/client/src/connection/protobuf-client.ts
@@ -32,9 +32,7 @@ export class ProtobufSocketClient extends TypedEmitter<Events> {
   }
 
   public send(message: ClientToServerMessage) {
-    console.log(performance.now(), 'encoding message');
     const encoded = encode(message);
-    console.log(performance.now(), 'sending message');
     this.socket.send(encoded);
   }
 }

--- a/packages/client/src/controllers/line-controller.ts
+++ b/packages/client/src/controllers/line-controller.ts
@@ -1,13 +1,30 @@
 import { v4 } from 'uuid';
-import { Coordinates } from '../protocol/protocol';
-import { localAddLine } from '../store/lines';
+import {
+  makeAddPointsToLineMessage,
+  makeCreateLineMessage
+} from '../connection/messages';
+import { reqResponseService } from '../connection/ServerContext';
+import { ClientToServerMessage } from '../protocol/protocol';
+import { discardPatch, localAddLine, localAddPoints } from '../store/lines';
 import { Line } from '../types';
 
-export const addLine = (points: Line['points']) => {
+export const addLine = (points: Line['points']): Readonly<Line> => {
   const line = { id: v4(), points };
   const patchId = localAddLine(line);
-  // const body: ClientToServerMessage['body'] = makeCreateNoteMessage(line);
-  // reqResponseService.send(body, () => {
-  //   discardPatch(line.id, patchId);
-  // });
+  const body: ClientToServerMessage['body'] = makeCreateLineMessage(line);
+  reqResponseService.send(body, () => {
+    discardPatch(line.id, patchId);
+  });
+  return { id: line.id, points: Array.from(line.points) };
+};
+
+export const addPointsToLine = (id: Line['id'], points: Line['points']) => {
+  const patchId = localAddPoints(id, points);
+  const body: ClientToServerMessage['body'] = makeAddPointsToLineMessage(
+    id,
+    points
+  );
+  reqResponseService.send(body, () => {
+    discardPatch(id, patchId);
+  });
 };

--- a/packages/client/src/controllers/line-controller.ts
+++ b/packages/client/src/controllers/line-controller.ts
@@ -1,0 +1,13 @@
+import { v4 } from 'uuid';
+import { Coordinates } from '../protocol/protocol';
+import { localAddLine } from '../store/lines';
+import { Line } from '../types';
+
+export const addLine = (points: Line['points']) => {
+  const line = { id: v4(), points };
+  const patchId = localAddLine(line);
+  // const body: ClientToServerMessage['body'] = makeCreateNoteMessage(line);
+  // reqResponseService.send(body, () => {
+  //   discardPatch(line.id, patchId);
+  // });
+};

--- a/packages/client/src/editor/components/Editor.tsx
+++ b/packages/client/src/editor/components/Editor.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { useRecoilState } from 'recoil';
 import { addNote } from '../../controllers/note-controller';
+import { useEffectiveLines } from '../../store/hooks';
 import render from '../render';
 import { modeState } from '../state';
 import {
@@ -17,6 +18,7 @@ import Tools from './Tools';
 import UndoTool from './UndoTool';
 
 const Editor = (props: { x: number; y: number }) => {
+  const effectiveLines = [...useEffectiveLines().values()];
   const canvas = useRef<HTMLCanvasElement>(null);
 
   const getCtx = () => {
@@ -63,7 +65,7 @@ const Editor = (props: { x: number; y: number }) => {
         } else if (mode === 'erase') {
           appendErase(point);
         }
-        render(getCtx()!, canvas.current!);
+        render(getCtx()!, canvas.current!, effectiveLines);
       }
     },
     [mode, pointerDown]
@@ -71,7 +73,7 @@ const Editor = (props: { x: number; y: number }) => {
 
   const renderUndo = () => {
     undo();
-    render(getCtx()!, canvas.current!);
+    render(getCtx()!, canvas.current!, effectiveLines);
   };
 
   useEffect(() => {
@@ -100,9 +102,8 @@ const Editor = (props: { x: number; y: number }) => {
 
   // Main render function
   useEffect(() => {
-    const timer = setInterval(() => render(getCtx()!, canvas.current!), 500);
-    return () => clearInterval(timer);
-  }, []);
+    render(getCtx()!, canvas.current!, [...effectiveLines.values()]);
+  }, [effectiveLines]);
 
   return (
     <div

--- a/packages/client/src/editor/components/Editor.tsx
+++ b/packages/client/src/editor/components/Editor.tsx
@@ -65,7 +65,6 @@ const Editor = (props: { x: number; y: number }) => {
         } else if (mode === 'erase') {
           appendErase(point);
         }
-        render(getCtx()!, canvas.current!, effectiveLines);
       }
     },
     [mode, pointerDown]
@@ -73,7 +72,6 @@ const Editor = (props: { x: number; y: number }) => {
 
   const renderUndo = () => {
     undo();
-    render(getCtx()!, canvas.current!, effectiveLines);
   };
 
   useEffect(() => {

--- a/packages/client/src/editor/render.ts
+++ b/packages/client/src/editor/render.ts
@@ -17,6 +17,7 @@ const render = (
   if (ctx == null) {
     throw new Error('no ctx');
   }
+  console.log('canvas render');
   reset(ctx, canvas);
 
   ctx.fillStyle = '#000000';

--- a/packages/client/src/editor/render.ts
+++ b/packages/client/src/editor/render.ts
@@ -1,7 +1,7 @@
 //import React, { useCallback, useEffect, useRef} from "react";
 //import { isContext } from "vm";
 //import {Coordinate} from '../types';
-import { lines } from './whiteboard';
+import { Line } from '../types';
 
 const reset = (ctx: CanvasRenderingContext2D, canvas: HTMLCanvasElement) => {
   ctx.setTransform(1, 0, 0, 1, 0, 0);
@@ -9,7 +9,11 @@ const reset = (ctx: CanvasRenderingContext2D, canvas: HTMLCanvasElement) => {
   ctx.fillRect(0, 0, canvas.width, canvas.height);
 };
 
-const render = (ctx: CanvasRenderingContext2D, canvas: HTMLCanvasElement) => {
+const render = (
+  ctx: CanvasRenderingContext2D,
+  canvas: HTMLCanvasElement,
+  lines: Line[]
+) => {
   if (ctx == null) {
     throw new Error('no ctx');
   }

--- a/packages/client/src/editor/render.ts
+++ b/packages/client/src/editor/render.ts
@@ -17,11 +17,10 @@ const render = (
   if (ctx == null) {
     throw new Error('no ctx');
   }
-  console.log('canvas render');
   reset(ctx, canvas);
 
   ctx.fillStyle = '#000000';
-  console.debug(`bitmap render: drawing ${lines.length} lines`);
+  console.debug(`canvas render: drawing ${lines.length} lines`);
   lines.forEach(line => {
     line.points.forEach(point => {
       ctx.fillRect(

--- a/packages/client/src/editor/whiteboard.ts
+++ b/packages/client/src/editor/whiteboard.ts
@@ -23,7 +23,7 @@ const UUID_NAMESPACE = '940beed9-f057-4088-a714-a9f5f2fc6052';
 export const startLine = (point: Coordinates) => {
   drawing = true;
   lines.push({
-    UUID: v5('line' + (lines.length - 1).toString(), UUID_NAMESPACE),
+    id: v5('line' + (lines.length - 1).toString(), UUID_NAMESPACE),
     points: new Set()
   }); // placeholder UUID
   lines[lines.length - 1].points.add(point);
@@ -43,7 +43,7 @@ export const appendLine = (point: Coordinates) => {
 export const finishLine = () => {
   history.push({
     type: 'draw',
-    UUID: lines[lines.length - 1].UUID
+    id: lines[lines.length - 1].id
   });
   drawing = false;
 
@@ -79,10 +79,10 @@ const updateErase = () => {
       line.points.forEach(point => {
         if (coord.x == point.x && coord.y == point.y) {
           line.points.delete(point); // This pixel will not be rendered anymore
-          if (!erasedPixels.has(line.UUID)) {
-            erasedPixels.set(line.UUID, [coord]); // and the erased pixel is added by UUID to erasedPixels...
+          if (!erasedPixels.has(line.id)) {
+            erasedPixels.set(line.id, [coord]); // and the erased pixel is added by UUID to erasedPixels...
           } else {
-            let erasedCoords = erasedPixels.get(line.UUID);
+            let erasedCoords = erasedPixels.get(line.id);
             erasedCoords!.push(coord);
           }
         }
@@ -112,8 +112,8 @@ export const undo = () => {
   let lastAction = history[history.length - 1];
 
   if (lastAction.type == 'draw') {
-    let id = lastAction.UUID;
-    let index = lines.findIndex(x => findFunction(x.UUID, id));
+    let id = lastAction.id;
+    let index = lines.findIndex(x => findFunction(x.id, id));
     if (index != -1) {
       lines.splice(index, 1);
     }
@@ -123,7 +123,7 @@ export const undo = () => {
     // TODO send update to server
   } else if (lastAction.type == 'erase') {
     lastAction.lines.forEach((modifiedPixels, uuid) => {
-      let index = lines.findIndex(x => findFunction(uuid, x.UUID));
+      let index = lines.findIndex(x => findFunction(uuid, x.id));
       if (index != -1) {
         modifiedPixels.forEach(coord => {
           lines[index].points.add(coord);

--- a/packages/client/src/editor/whiteboard.ts
+++ b/packages/client/src/editor/whiteboard.ts
@@ -35,8 +35,8 @@ export const appendLine = (point: Coordinates) => {
     return;
   }
   let points = linePoints(lastPos!, point);
-  lines[lines.length - 1].points = R.union(
-    lines[lines.length - 1].points,
+
+  lines[lines.length - 1].points = lines[lines.length - 1].points.concat(
     points
   );
   lastPos = point;

--- a/packages/client/src/editor/whiteboard.ts
+++ b/packages/client/src/editor/whiteboard.ts
@@ -4,6 +4,7 @@ import { reqResponseService } from '../connection/ServerContext';
 import { Action, Coordinates, Img, Line, UUID } from '../types';
 import { erasePoints, linePoints } from './math';
 import * as R from 'ramda';
+import { addLine, addPointsToLine } from '../controllers/line-controller';
 
 export const lines: Line[] = [];
 
@@ -23,10 +24,8 @@ const UUID_NAMESPACE = '940beed9-f057-4088-a714-a9f5f2fc6052';
 
 export const startLine = (point: Coordinates) => {
   drawing = true;
-  lines.push({
-    id: v5('line' + (lines.length - 1).toString(), UUID_NAMESPACE),
-    points: [point]
-  }); // placeholder UUID
+  const newLine = addLine([point]);
+  lines.push(newLine);
   lastPos = point;
 };
 
@@ -34,13 +33,10 @@ export const appendLine = (point: Coordinates) => {
   if (!drawing) {
     return;
   }
-  let points = linePoints(lastPos!, point);
+  let newPoints = linePoints(lastPos!, point);
 
-  lines[lines.length - 1].points = lines[lines.length - 1].points.concat(
-    points
-  );
+  addPointsToLine(lines[lines.length - 1].id, newPoints);
   lastPos = point;
-  reqResponseService.send(lineToMessage(lines[lines.length - 1]));
 };
 
 export const finishLine = () => {
@@ -51,7 +47,7 @@ export const finishLine = () => {
   drawing = false;
 
   // TODO send update request to server
-  reqResponseService.send(lineToMessage(lines[lines.length - 1]));
+  // reqResponseService.send(lineToMessage(lines[lines.length - 1]));
 };
 
 export const startErase = (point: Coordinates) => {

--- a/packages/client/src/store/hooks.ts
+++ b/packages/client/src/store/hooks.ts
@@ -7,6 +7,6 @@ export const useEffectiveNotes = () => {
 };
 
 export const useEffectiveLines = () => {
-  const storeSnapshot = useSnapshot(store, { sync: true });
+  const storeSnapshot = useSnapshot(store);
   return getEffectiveLines(storeSnapshot.lineTimelines);
 };

--- a/packages/client/src/store/hooks.ts
+++ b/packages/client/src/store/hooks.ts
@@ -1,7 +1,12 @@
 import { useSnapshot } from 'valtio';
-import { getEffectiveNotes, store } from '.';
+import { getEffectiveLines, getEffectiveNotes, store } from '.';
 
 export const useEffectiveNotes = () => {
-  const noteTimelinesSnapshot = useSnapshot(store);
-  return getEffectiveNotes(noteTimelinesSnapshot.noteTimelines);
+  const storeSnapshot = useSnapshot(store);
+  return getEffectiveNotes(storeSnapshot.noteTimelines);
+};
+
+export const useEffectiveLines = () => {
+  const storeSnapshot = useSnapshot(store);
+  return getEffectiveLines(storeSnapshot.lineTimelines);
 };

--- a/packages/client/src/store/hooks.ts
+++ b/packages/client/src/store/hooks.ts
@@ -1,4 +1,5 @@
-import { useSnapshot } from 'valtio';
+import { useState, useEffect } from 'react';
+import { useSnapshot, subscribe } from 'valtio';
 import { getEffectiveLines, getEffectiveNotes, store } from '.';
 
 export const useEffectiveNotes = () => {
@@ -7,6 +8,17 @@ export const useEffectiveNotes = () => {
 };
 
 export const useEffectiveLines = () => {
-  const storeSnapshot = useSnapshot(store);
-  return getEffectiveLines(storeSnapshot.lineTimelines);
+  const [effectiveLines, setEffectiveLines] = useState<
+    ReturnType<typeof getEffectiveLines>
+  >(new Map());
+  // Use the mutable store to compue effective lines.
+  // Skipping snapshot generation greatly improves performance
+  useEffect(
+    () =>
+      subscribe(store.lineTimelines, () => {
+        setEffectiveLines(getEffectiveLines(store.lineTimelines));
+      }),
+    [store.lineTimelines]
+  );
+  return effectiveLines;
 };

--- a/packages/client/src/store/hooks.ts
+++ b/packages/client/src/store/hooks.ts
@@ -1,3 +1,4 @@
+import debounce from 'just-debounce';
 import { useEffect, useState } from 'react';
 import { getEffectiveLines, getEffectiveNotes } from '.';
 
@@ -7,6 +8,8 @@ let noteListeners: React.Dispatch<
 let lineListeners: React.Dispatch<
   React.SetStateAction<ReturnType<typeof getEffectiveLines>>
 >[] = [];
+
+const STATE_UPDATE_FREQUENCY_MS = 10;
 
 export const useEffectiveNotes = () => {
   const [state, setState] = useState(getEffectiveNotes());
@@ -39,9 +42,14 @@ export const sendNotesUpdate = () => {
   }
 };
 
-export const sendLinesUpdate = () => {
-  const newState = getEffectiveLines();
-  for (const listener of lineListeners) {
-    listener(newState);
-  }
-};
+export const sendLinesUpdate = debounce(
+  () => {
+    const newState = getEffectiveLines();
+    for (const listener of lineListeners) {
+      listener(newState);
+    }
+  },
+  STATE_UPDATE_FREQUENCY_MS,
+  true,
+  true
+);

--- a/packages/client/src/store/hooks.ts
+++ b/packages/client/src/store/hooks.ts
@@ -7,6 +7,6 @@ export const useEffectiveNotes = () => {
 };
 
 export const useEffectiveLines = () => {
-  const storeSnapshot = useSnapshot(store);
+  const storeSnapshot = useSnapshot(store, { sync: true });
   return getEffectiveLines(storeSnapshot.lineTimelines);
 };

--- a/packages/client/src/store/index.ts
+++ b/packages/client/src/store/index.ts
@@ -1,13 +1,18 @@
-import { proxy, subscribe } from 'valtio';
-import type { Note } from '../types';
+import { proxy } from 'valtio';
+import type { Line, Note } from '../types';
 import { removeNullish } from '../utils';
+import { getEffectiveLine, LineTimeline } from './timelines/line';
 import { getEffectiveNote, NoteTimeline } from './timelines/note';
 
 type Store = {
   noteTimelines: { [noteId: string]: NoteTimeline };
+  lineTimelines: { [lineId: string]: LineTimeline };
 };
 
-export const store: Store = proxy({ noteTimelines: Object.create(null) });
+export const store: Store = proxy({
+  noteTimelines: Object.create(null),
+  lineTimelines: Object.create(null)
+});
 
 export const getEffectiveNotes = (
   noteTimelinesSnapshot: Readonly<Store['noteTimelines']>
@@ -17,5 +22,16 @@ export const getEffectiveNotes = (
     removeNullish(
       noteTimelinesArray.map(nt => getEffectiveNote(nt))
     ).map(note => [note.id, note])
+  );
+};
+
+export const getEffectiveLines = (
+  lineTimelinesSnapshot: Readonly<Store['lineTimelines']>
+): Map<Line['id'], Line> => {
+  const lineTimelinesArray = Object.values(lineTimelinesSnapshot);
+  return new Map(
+    removeNullish(
+      lineTimelinesArray.map(lt => getEffectiveLine(lt))
+    ).map(line => [line.id, line])
   );
 };

--- a/packages/client/src/store/index.ts
+++ b/packages/client/src/store/index.ts
@@ -1,23 +1,32 @@
-import { proxy } from 'valtio';
 import type { Line, Note } from '../types';
 import { removeNullish } from '../utils';
+import { sendLinesUpdate, sendNotesUpdate } from './hooks';
 import { getEffectiveLine, LineTimeline } from './timelines/line';
 import { getEffectiveNote, NoteTimeline } from './timelines/note';
 
-type Store = {
-  noteTimelines: { [noteId: string]: NoteTimeline };
-  lineTimelines: { [lineId: string]: LineTimeline };
+const noteTimelines: { [noteId: string]: NoteTimeline } = Object.create(null);
+const lineTimelines: { [lineId: string]: LineTimeline } = Object.create(null);
+
+export const updateNotes = <T>(
+  callback: (nTimelines: typeof noteTimelines) => T
+): T => {
+  // Legacy function from before valtio introduction
+  const result = callback(noteTimelines);
+  sendNotesUpdate();
+  return result;
 };
 
-export const store: Store = proxy({
-  noteTimelines: Object.create(null),
-  lineTimelines: Object.create(null)
-});
+export const updateLineStore = <T>(
+  callback: (lTimelines: typeof lineTimelines) => T
+): T => {
+  // Legacy function from before valtio introduction
+  const result = callback(lineTimelines);
+  sendLinesUpdate();
+  return result;
+};
 
-export const getEffectiveNotes = (
-  noteTimelinesSnapshot: Readonly<Store['noteTimelines']>
-): Map<Note['id'], Note> => {
-  const noteTimelinesArray = Object.values(noteTimelinesSnapshot);
+export const getEffectiveNotes = (): Map<Note['id'], Note> => {
+  const noteTimelinesArray = Object.values(noteTimelines);
   return new Map(
     removeNullish(
       noteTimelinesArray.map(nt => getEffectiveNote(nt))
@@ -25,10 +34,8 @@ export const getEffectiveNotes = (
   );
 };
 
-export const getEffectiveLines = (
-  lineTimelinesSnapshot: Readonly<Store['lineTimelines']>
-): Map<Line['id'], Line> => {
-  const lineTimelinesArray = Object.values(lineTimelinesSnapshot);
+export const getEffectiveLines = (): Map<Line['id'], Line> => {
+  const lineTimelinesArray = Object.values(lineTimelines);
   return new Map(
     removeNullish(
       lineTimelinesArray.map(lt => getEffectiveLine(lt))

--- a/packages/client/src/store/index.ts
+++ b/packages/client/src/store/index.ts
@@ -1,7 +1,7 @@
 import { proxy, subscribe } from 'valtio';
 import type { Note } from '../types';
 import { removeNullish } from '../utils';
-import { getNewestLocalState, NoteTimeline } from './timelines/note';
+import { getEffectiveNote, NoteTimeline } from './timelines/note';
 
 type Store = {
   noteTimelines: { [noteId: string]: NoteTimeline };
@@ -15,7 +15,7 @@ export const getEffectiveNotes = (
   const noteTimelinesArray = Object.values(noteTimelinesSnapshot);
   return new Map(
     removeNullish(
-      noteTimelinesArray.map(nt => getNewestLocalState(nt))
+      noteTimelinesArray.map(nt => getEffectiveNote(nt))
     ).map(note => [note.id, note])
   );
 };

--- a/packages/client/src/store/lines.ts
+++ b/packages/client/src/store/lines.ts
@@ -1,4 +1,4 @@
-import { store } from '.';
+import { updateLineStore } from '.';
 import { Coordinates } from '../protocol/protocol';
 import { Line, UUID } from '../types';
 import * as lineTimeline from './timelines/line';
@@ -7,45 +7,53 @@ import { newLocalLineTimeline } from './timelines/line';
 type PatchId = UUID;
 
 export const localAddLine = (line: Line) => {
-  const { timeline, figureId, patchId } = newLocalLineTimeline(line);
-  store.lineTimelines[figureId] = timeline;
-  return patchId;
+  return updateLineStore(lineTimelines => {
+    const { timeline, figureId, patchId } = newLocalLineTimeline(line);
+    lineTimelines[figureId] = timeline;
+    return patchId;
+  });
 };
 
 export const localAddPoints = (
   id: Line['id'],
   points: Line['points']
 ): PatchId => {
-  const oldTimeline = store.lineTimelines[id];
-  if (!oldTimeline) {
-    throw new Error('Tried updating text of a line without a LineTimeline');
-  }
-  const { patchId, timeline, figureId } = lineTimeline.patchAddPoints(
-    oldTimeline,
-    points
-  );
-  store.lineTimelines[figureId] = timeline;
-  return patchId;
+  return updateLineStore(lineTimelines => {
+    const oldTimeline = lineTimelines[id];
+    if (!oldTimeline) {
+      throw new Error('Tried updating text of a line without a LineTimeline');
+    }
+    const { patchId, timeline, figureId } = lineTimeline.patchAddPoints(
+      oldTimeline,
+      points
+    );
+    lineTimelines[figureId] = timeline;
+    return patchId;
+  });
 };
 
 export const setServerState = (id: Line['id'], state: Line | null) => {
-  let lt = store.lineTimelines[id];
-  if (!lt) {
-    if (state === null) {
-      // if have nothing to delete
-      return;
+  return updateLineStore(lineTimelines => {
+    let lt = lineTimelines[id];
+    if (!lt) {
+      if (state === null) {
+        // if have nothing to delete
+        return;
+      } else {
+        lt = lineTimeline.newCommittedLineTimeline(state);
+      }
     } else {
-      lt = lineTimeline.newCommittedLineTimeline(state);
+      lt = lineTimeline.setCommitted(lt, state);
     }
-  } else {
-    lt = lineTimeline.setCommitted(lt, state);
-  }
-  store.lineTimelines[lt.figureId] = lt;
+    lineTimelines[lt.figureId] = lt;
+  });
 };
 
 export const discardPatch = (figureId: Line['id'], patchId: PatchId) => {
-  let nt = store.lineTimelines[figureId];
-  if (nt) {
-    store.lineTimelines[figureId] = lineTimeline.discardPatch(nt, patchId);
-  }
+  return updateLineStore(lineTimelines => {
+    let nt = lineTimelines[figureId];
+    if (nt) {
+      lineTimelines[figureId] = lineTimeline.discardPatch(nt, patchId);
+    }
+  });
 };

--- a/packages/client/src/store/lines.ts
+++ b/packages/client/src/store/lines.ts
@@ -1,0 +1,36 @@
+import { store } from '.';
+import { Coordinates } from '../protocol/protocol';
+import { Line, UUID } from '../types';
+import * as lineTimeline from './timelines/line';
+import { newLocalLineTimeline } from './timelines/line';
+
+type PatchId = UUID;
+
+export const localAddLine = (line: Line) => {
+  const { timeline, figureId, patchId } = newLocalLineTimeline(line);
+  store.lineTimelines[figureId] = timeline;
+  return patchId;
+};
+
+export const localAddPoints = (
+  id: Line['id'],
+  points: Line['points']
+): PatchId => {
+  const oldTimeline = store.lineTimelines[id];
+  if (!oldTimeline) {
+    throw new Error('Tried updating text of a line without a LineTimeline');
+  }
+  const { patchId, timeline, figureId } = lineTimeline.patchAddPoints(
+    oldTimeline,
+    points
+  );
+  store.lineTimelines[figureId] = timeline;
+  return patchId;
+};
+
+export const discardPatch = (figureId: Line['id'], patchId: PatchId) => {
+  let nt = store.lineTimelines[figureId];
+  if (nt) {
+    store.lineTimelines[figureId] = lineTimeline.discardPatch(nt, patchId);
+  }
+};

--- a/packages/client/src/store/lines.ts
+++ b/packages/client/src/store/lines.ts
@@ -28,6 +28,21 @@ export const localAddPoints = (
   return patchId;
 };
 
+export const setServerState = (id: Line['id'], state: Line | null) => {
+  let lt = store.lineTimelines[id];
+  if (!lt) {
+    if (state === null) {
+      // if have nothing to delete
+      return;
+    } else {
+      lt = lineTimeline.newCommittedLineTimeline(state);
+    }
+  } else {
+    lt = lineTimeline.setCommitted(lt, state);
+  }
+  store.lineTimelines[lt.figureId] = lt;
+};
+
 export const discardPatch = (figureId: Line['id'], patchId: PatchId) => {
   let nt = store.lineTimelines[figureId];
   if (nt) {

--- a/packages/client/src/store/notes.ts
+++ b/packages/client/src/store/notes.ts
@@ -2,8 +2,8 @@ import { store } from '.';
 import { Note, UUID } from '../types';
 import * as noteTimeline from './timelines/note';
 import {
-  modifyDelete,
-  modifyText,
+  patchDeleteNote,
+  patchText,
   newCommittedNoteTimeline,
   newLocalNoteTimeline,
   setCommitted
@@ -23,7 +23,7 @@ export const localDeleteNote = (id: Note['id']): PatchId | null => {
   if (!oldTimeline) {
     return null;
   }
-  const { patchId, timeline, figureId } = modifyDelete(oldTimeline);
+  const { patchId, timeline, figureId } = patchDeleteNote(oldTimeline);
   store.noteTimelines[figureId] = timeline;
   return patchId;
 };
@@ -33,7 +33,7 @@ export const localUpdateText = (id: Note['id'], newText: string): PatchId => {
   if (!oldTimeline) {
     throw new Error('Tried updating text of a note without a NoteTimeline');
   }
-  const { patchId, timeline, figureId } = modifyText(oldTimeline, newText);
+  const { patchId, timeline, figureId } = patchText(oldTimeline, newText);
   store.noteTimelines[figureId] = timeline;
   return patchId;
 };

--- a/packages/client/src/store/notes.ts
+++ b/packages/client/src/store/notes.ts
@@ -11,7 +11,6 @@ import {
 
 type PatchId = UUID;
 
-// TODO change name, if we are doing server push in this function
 export const localAddNote = (note: Note) => {
   const { timeline, figureId, patchId } = newLocalNoteTimeline(note);
   store.noteTimelines[figureId] = timeline;

--- a/packages/client/src/store/notes.ts
+++ b/packages/client/src/store/notes.ts
@@ -1,4 +1,4 @@
-import { store } from '.';
+import { updateNotes as updateNoteStore } from '.';
 import { Note, UUID } from '../types';
 import * as noteTimeline from './timelines/note';
 import {
@@ -12,49 +12,59 @@ import {
 type PatchId = UUID;
 
 export const localAddNote = (note: Note) => {
-  const { timeline, figureId, patchId } = newLocalNoteTimeline(note);
-  store.noteTimelines[figureId] = timeline;
-  return patchId;
+  return updateNoteStore(noteTimelines => {
+    const { timeline, figureId, patchId } = newLocalNoteTimeline(note);
+    noteTimelines[figureId] = timeline;
+    return patchId;
+  });
 };
 
 export const localDeleteNote = (id: Note['id']): PatchId | null => {
-  const oldTimeline = store.noteTimelines[id];
-  if (!oldTimeline) {
-    return null;
-  }
-  const { patchId, timeline, figureId } = patchDeleteNote(oldTimeline);
-  store.noteTimelines[figureId] = timeline;
-  return patchId;
+  return updateNoteStore(noteTimelines => {
+    const oldTimeline = noteTimelines[id];
+    if (!oldTimeline) {
+      return null;
+    }
+    const { patchId, timeline, figureId } = patchDeleteNote(oldTimeline);
+    noteTimelines[figureId] = timeline;
+    return patchId;
+  });
 };
 
 export const localUpdateText = (id: Note['id'], newText: string): PatchId => {
-  const oldTimeline = store.noteTimelines[id];
-  if (!oldTimeline) {
-    throw new Error('Tried updating text of a note without a NoteTimeline');
-  }
-  const { patchId, timeline, figureId } = patchText(oldTimeline, newText);
-  store.noteTimelines[figureId] = timeline;
-  return patchId;
+  return updateNoteStore(noteTimelines => {
+    const oldTimeline = noteTimelines[id];
+    if (!oldTimeline) {
+      throw new Error('Tried updating text of a note without a NoteTimeline');
+    }
+    const { patchId, timeline, figureId } = patchText(oldTimeline, newText);
+    noteTimelines[figureId] = timeline;
+    return patchId;
+  });
 };
 
 export const setServerState = (id: Note['id'], state: Note | null) => {
-  let nt = store.noteTimelines[id];
-  if (!nt) {
-    if (state === null) {
-      // if have nothing to delete
-      return;
+  return updateNoteStore(noteTimelines => {
+    let nt = noteTimelines[id];
+    if (!nt) {
+      if (state === null) {
+        // if have nothing to delete
+        return;
+      } else {
+        nt = newCommittedNoteTimeline(state);
+      }
     } else {
-      nt = newCommittedNoteTimeline(state);
+      nt = setCommitted(nt, state);
     }
-  } else {
-    nt = setCommitted(nt, state);
-  }
-  store.noteTimelines[nt.figureId] = nt;
+    noteTimelines[nt.figureId] = nt;
+  });
 };
 
 export const discardPatch = (figureId: Note['id'], patchId: PatchId) => {
-  let nt = store.noteTimelines[figureId];
-  if (nt) {
-    store.noteTimelines[figureId] = noteTimeline.discardPatch(nt, patchId);
-  }
+  return updateNoteStore(noteTimelines => {
+    let nt = noteTimelines[figureId];
+    if (nt) {
+      noteTimelines[figureId] = noteTimeline.discardPatch(nt, patchId);
+    }
+  });
 };

--- a/packages/client/src/store/timelines/line.ts
+++ b/packages/client/src/store/timelines/line.ts
@@ -1,6 +1,5 @@
-import { METHODS } from 'node:http';
 import { v4 } from 'uuid';
-import type { Coordinates, UUID, Line } from '../../types';
+import type { Coordinates, Line, UUID } from '../../types';
 
 // TODO functions below should probably validate
 // that after 'deleted' there can't be newer patches
@@ -36,6 +35,19 @@ const newPatch = (diff: Diff): Patch => ({
   id: v4(),
   diff
 });
+
+// export const getEffectiveLine = (lt: LineTimeline): Line | null => {
+//   const current: Line = lt.committed ?? { id: lt.figureId, points: new Set() };
+//   for (const { diff } of lt.patches) {
+//     if (diff.type === 'LINE_DELETED') {
+//       return null;
+//     } else if (diff.type === 'ADD_POINTS') {
+//       diff.points.forEach(p => current.points.add(p));
+//     } else {
+//       diff.
+//     }
+//   }
+// };
 
 export const newCommittedLineTimeline = (initial: Line): LineTimeline => ({
   figureId: initial.id,

--- a/packages/client/src/store/timelines/line.ts
+++ b/packages/client/src/store/timelines/line.ts
@@ -1,5 +1,6 @@
 import * as R from 'ramda';
 import { v4 } from 'uuid';
+import { lineToMessage } from '../../connection/messages';
 import type { Coordinates, Line, UUID } from '../../types';
 
 // TODO functions below should probably validate
@@ -38,7 +39,10 @@ const newPatch = (diff: Diff): Patch => ({
 });
 
 export const getEffectiveLine = (lt: LineTimeline): Line | null => {
-  const current: Line = lt.committed ?? { id: lt.figureId, points: [] };
+  const current: Line = lt.committed
+    ? { ...lt.committed }
+    : { id: lt.figureId, points: [] };
+  console.debug(`Flattening ${lt.patches.length} line patches`);
   for (const { diff } of lt.patches) {
     switch (diff.type) {
       case 'LINE_DELETED':

--- a/packages/client/src/store/timelines/line.ts
+++ b/packages/client/src/store/timelines/line.ts
@@ -7,16 +7,16 @@ type Diff =
   | { type: 'LINE_DELETED' }
   | {
       type: 'ADD_POINTS';
-      points: Set<Coordinates>;
+      points: Readonly<Coordinates[]>;
     }
   | {
       type: 'REMOVE_POINTS';
-      points: Set<Coordinates>;
+      points: Readonly<Coordinates[]>;
     };
 
 type Patch = {
-  id: UUID;
-  diff: Diff;
+  readonly id: UUID;
+  readonly diff: Diff;
 };
 
 type Result = {
@@ -55,28 +55,28 @@ export const newCommittedLineTimeline = (initial: Line): LineTimeline => ({
   patches: []
 });
 
-export const newLocalLineTimeline = (initial: Line): Result => {
+export const newLocalLineTimeline = ({ id, points }: Line): Result => {
   const patch = newPatch({
     type: 'ADD_POINTS',
-    points: new Set(initial.points)
+    points: Object.freeze(points)
   });
   const timeline: LineTimeline = {
-    figureId: initial.id,
+    figureId: id,
     committed: null,
     patches: [patch]
   };
   return {
     timeline,
     patchId: patch.id,
-    figureId: initial.id
+    figureId: id
   };
 };
 
 export const patchAddPoints = (
   lt: LineTimeline,
-  points: Set<Coordinates>
+  points: Coordinates[]
 ): Result => {
-  const patch = newPatch({ type: 'ADD_POINTS', points: new Set(points) });
+  const patch = newPatch({ type: 'ADD_POINTS', points: Object.freeze(points) });
   const timeline = {
     ...lt,
     patches: lt.patches.concat(patch)

--- a/packages/client/src/store/timelines/line.ts
+++ b/packages/client/src/store/timelines/line.ts
@@ -1,0 +1,61 @@
+import { METHODS } from 'node:http';
+import { v4 } from 'uuid';
+import type { Coordinates, UUID, Line } from '../../types';
+
+// TODO functions below should probably validate
+// that after 'deleted' there can't be newer patches
+type Diff =
+  | { type: 'LINE_DELETED' }
+  | {
+      type: 'ADD_POINTS';
+      points: Set<Coordinates>;
+    }
+  | {
+      type: 'REMOVE_POINTS';
+      points: Set<Coordinates>;
+    };
+
+type Patch = {
+  id: UUID;
+  diff: Diff;
+};
+
+type Result = {
+  timeline: LineTimeline;
+  patchId: Patch['id'];
+  figureId: UUID;
+};
+
+export type LineTimeline = {
+  figureId: UUID;
+  committed: Line | null;
+  patches: Patch[];
+};
+
+const newPatch = (diff: Diff): Patch => ({
+  id: v4(),
+  diff
+});
+
+export const newCommittedLineTimeline = (initial: Line): LineTimeline => ({
+  figureId: initial.id,
+  committed: initial,
+  patches: []
+});
+
+export const newLocalLineTimeline = (initial: Line): Result => {
+  const patch = newPatch({
+    type: 'ADD_POINTS',
+    points: new Set(initial.points)
+  });
+  const timeline: LineTimeline = {
+    figureId: initial.id,
+    committed: null,
+    patches: [patch]
+  };
+  return {
+    timeline,
+    patchId: patch.id,
+    figureId: initial.id
+  };
+};

--- a/packages/client/src/store/timelines/line.ts
+++ b/packages/client/src/store/timelines/line.ts
@@ -59,3 +59,19 @@ export const newLocalLineTimeline = (initial: Line): Result => {
     figureId: initial.id
   };
 };
+
+export const patchAddPoints = (
+  lt: LineTimeline,
+  points: Set<Coordinates>
+): Result => {
+  const patch = newPatch({ type: 'ADD_POINTS', points: new Set(points) });
+  const timeline = {
+    ...lt,
+    patches: lt.patches.concat(patch)
+  };
+  return {
+    timeline,
+    patchId: patch.id,
+    figureId: lt.figureId
+  };
+};

--- a/packages/client/src/store/timelines/line.ts
+++ b/packages/client/src/store/timelines/line.ts
@@ -39,28 +39,21 @@ const newPatch = (diff: Diff): Patch => ({
 
 export const getEffectiveLine = (lt: LineTimeline): Line | null => {
   // store coords as strings to allow storage in Set
-  const pointJSONs: Set<string> = lt.committed
-    ? new Set(lt.committed.points.map(p => JSON.stringify(p)))
-    : new Set();
+  let points: Coordinates[] = lt.committed ? lt.committed.points : [];
 
   for (const { diff } of lt.patches) {
     switch (diff.type) {
       case 'LINE_DELETED':
         return null;
       case 'ADD_POINTS':
-        // does not preserve uniqueness, but it will be resolved
-        // in the next REMOVE_POINTS or on returning
-        diff.points.forEach(p => pointJSONs.add(JSON.stringify(p)));
+        points = points.concat(diff.points);
         break;
       case 'REMOVE_POINTS':
-        diff.points.forEach(p => pointJSONs.delete(JSON.stringify(p)));
+        points = R.without(diff.points, points);
         break;
     }
   }
-  return {
-    id: lt.figureId,
-    points: [...pointJSONs].map(s => JSON.parse(s))
-  };
+  return { id: lt.figureId, points };
 };
 
 export const newCommittedLineTimeline = (initial: Line): LineTimeline => ({

--- a/packages/client/src/store/timelines/line.ts
+++ b/packages/client/src/store/timelines/line.ts
@@ -1,6 +1,6 @@
+import * as R from 'ramda';
 import { v4 } from 'uuid';
 import type { Coordinates, Line, UUID } from '../../types';
-import * as R from 'ramda';
 
 // TODO functions below should probably validate
 // that after 'deleted' there can't be newer patches
@@ -96,3 +96,19 @@ export const patchAddPoints = (
     figureId: lt.figureId
   };
 };
+
+export const setCommitted = (
+  lt: LineTimeline,
+  committed: LineTimeline['committed']
+): LineTimeline => ({
+  ...lt,
+  committed
+});
+
+export const discardPatch = (
+  lt: LineTimeline,
+  changeId: Patch['id']
+): LineTimeline => ({
+  ...lt,
+  patches: lt.patches.filter(p => p.id !== changeId)
+});

--- a/packages/client/src/store/timelines/note.ts
+++ b/packages/client/src/store/timelines/note.ts
@@ -27,7 +27,7 @@ const newPatch = (diff: Diff): Patch => ({
   diff
 });
 
-export const getNewestLocalState = (nt: NoteTimeline): Note | null => {
+export const getEffectiveNote = (nt: NoteTimeline): Note | null => {
   // Flattens information about the note, going from newest patch to oldest
 
   const current: Partial<Note> = { id: nt.figureId };
@@ -79,7 +79,7 @@ export const newLocalNoteTimeline = (initial: Note): Result => {
   };
 };
 
-export const modifyText = (nt: NoteTimeline, newText: string): Result => {
+export const patchText = (nt: NoteTimeline, newText: string): Result => {
   const patch = newPatch({ text: newText });
   const timeline = {
     ...nt,
@@ -92,7 +92,7 @@ export const modifyText = (nt: NoteTimeline, newText: string): Result => {
   };
 };
 
-export const modifyPositiion = (
+export const patchPosition = (
   nt: NoteTimeline,
   newPosition: Coordinates
 ): NoteTimeline => {
@@ -102,7 +102,7 @@ export const modifyPositiion = (
   };
 };
 
-export const modifyDelete = (nt: NoteTimeline): Result => {
+export const patchDeleteNote = (nt: NoteTimeline): Result => {
   const patch = newPatch('deleted');
   const timeline = {
     ...nt,

--- a/packages/client/src/types.ts
+++ b/packages/client/src/types.ts
@@ -21,7 +21,7 @@ export type Action =
 
 export type Line = {
   id: UUID;
-  points: Set<Coordinates>;
+  points: Coordinates[];
 };
 
 export type Note = {

--- a/packages/client/src/types.ts
+++ b/packages/client/src/types.ts
@@ -12,7 +12,7 @@ export type Mode = 'draw' | 'erase' | 'note';
 export type Action =
   | {
       type: 'draw';
-      UUID: UUID;
+      id: UUID;
     }
   | {
       type: 'erase';
@@ -20,7 +20,7 @@ export type Action =
     };
 
 export type Line = {
-  UUID: UUID;
+  id: UUID;
   points: Set<Coordinates>;
 };
 
@@ -31,15 +31,9 @@ export type Note = {
 };
 
 export type Img = {
-  UUID: UUID;
+  id: UUID;
   position: Coordinates;
   data: string; // ts img object?
-};
-
-export type Object = {
-  UUID: UUID;
-  author: string;
-  type: Line | Note | Img;
 };
 
 export enum MessageCode {

--- a/protocol/protocol.proto
+++ b/protocol/protocol.proto
@@ -30,15 +30,18 @@ message Note {
   string text = 3;
 }
 
-message BitmapPoint {
-  Coordinates coordinates = 1;
-  int32 value = 2;
-}
-
 message Line {
   bytes id = 1;
-  repeated BitmapPoint bitmap = 2;
+  repeated Coordinates points = 2;
 }
+
+message CreateLine { Line line = 1; }
+message AddPointsToLine {
+  bytes line_id = 1;
+  repeated Coordinates points = 2;
+}
+
+message LineCreatedOrUpdated { Line line = 1; }
 
 message CreateNote { Note note = 1; }
 message UpdateNotePosition {
@@ -60,11 +63,12 @@ message ClientToServerMessage {
   oneof body {
     CreateWhiteboardRequest create_whiteboard_request = 1;
     JoinWhiteboard join_whiteboard = 2;
-    Line line_drawn = 6;
     CreateNote create_note = 7;
     UpdateNoteText update_note_text = 8;
     UpdateNotePosition update_note_position = 9;
     DeleteNote delete_note = 10;
+    CreateLine create_line = 20;
+    AddPointsToLine add_points_to_line = 21;
   }
 }
 
@@ -75,7 +79,7 @@ message ServerToClientMessage {
     ResultError error = 1;
     ResultSuccess success = 2;
     WhiteboardCreated whiteboard_created = 3;
-    Line line_drawn = 6;
+    LineCreatedOrUpdated line_created_or_updated = 6;
     NoteCreatedOrUpdated note_created_or_updated = 8;
     NoteDeleted note_deleted = 9;
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3163,6 +3163,13 @@
   resolved "https://registry.yarnpkg.com/@types/qs/-/qs-6.9.6.tgz#df9c3c8b31a247ec315e6996566be3171df4b3b1"
   integrity sha512-0/HnwIfW4ki2D8L8c9GVcG5I72s9jP5GSLVF0VIXDW00kmIpA6O33G7a8n59Tmh7Nz0WUC3rSb7PTY/sdW2JzA==
 
+"@types/ramda@^0.27.39":
+  version "0.27.39"
+  resolved "https://registry.yarnpkg.com/@types/ramda/-/ramda-0.27.39.tgz#7541d9d745a2003c8f635897dff8c65c12be9327"
+  integrity sha512-od24Hng0uS1NcMSPo6ZzKXN2WJxjbF7IBzQhRCtSDyIShdEJTAWXgQlyDg998aylNrXbVvQxkFJmuaLHQcfczg==
+  dependencies:
+    ts-toolbelt "^6.15.1"
+
 "@types/range-parser@*":
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/@types/range-parser/-/range-parser-1.2.3.tgz#7ee330ba7caafb98090bece86a5ee44115904c2c"
@@ -13169,6 +13176,11 @@ raf@^3.4.1:
   dependencies:
     performance-now "^2.1.0"
 
+ramda@^0.27.1:
+  version "0.27.1"
+  resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.27.1.tgz#66fc2df3ef873874ffc2da6aa8984658abacf5c9"
+  integrity sha512-PgIdVpn5y5Yns8vqb8FzBUEYn98V3xcPgawAkkgj0YJ0qDsnHCiNmZYfOGMgOvoB0eWFLpYbhxUR3mxfDIMvpw==
+
 randombytes@^2.0.0, randombytes@^2.0.1, randombytes@^2.0.5, randombytes@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/randombytes/-/randombytes-2.1.0.tgz#df6f84372f0270dc65cdf6291349ab7a473d4f2a"
@@ -15589,6 +15601,11 @@ ts-proto@^1.69.0:
     protobufjs "^6.8.8"
     ts-poet "^4.5.0"
     ts-proto-descriptors "^1.2.0"
+
+ts-toolbelt@^6.15.1:
+  version "6.15.5"
+  resolved "https://registry.yarnpkg.com/ts-toolbelt/-/ts-toolbelt-6.15.5.tgz#cb3b43ed725cb63644782c64fbcad7d8f28c0a83"
+  integrity sha512-FZIXf1ksVyLcfr7M317jbB67XFJhOO1YqdTcuGaq9q5jLUoTikukZ+98TPjKiP2jC5CgmYdWWYs0s2nLSU0/1A==
 
 tsconfig-paths@^3.9.0:
   version "3.9.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9919,6 +9919,11 @@ jss@10.5.1, jss@^10.5.1:
     array-includes "^3.1.2"
     object.assign "^4.1.2"
 
+just-debounce@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/just-debounce/-/just-debounce-1.1.0.tgz#2f81a3ad4121a76bc7cb45dbf704c0d76a8e5ddf"
+  integrity sha512-qpcRocdkUmf+UTNBYx5w6dexX5J31AKK1OmPwH630a83DdVVUIngk55RSAiIGpQyoH0dlr872VHfPjnQnK1qDQ==
+
 keyv@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/keyv/-/keyv-3.1.0.tgz#ecc228486f69991e49e9476485a5be1e8fc5c4d9"


### PR DESCRIPTION
Implements line drawing based on LineTimeline data structures. Lacks erase and undo at the moment.
Rolls back migration to Valtio -- I'm not 100% sure, but it seems to me from both manual tests and devtools flame graphs that valtio adds some unnecesary overhead because of tracking all modifications in nested objects of the global store and creation of snapshots for use by react components. The custom solution gives more possibilitie to fine tune it and better fit the application logic when triggering updates.  