### PR TITLE
Set websocket URL through environmental variable

### DIFF
--- a/packages/client/src/config.ts
+++ b/packages/client/src/config.ts
@@ -1,5 +1,4 @@
 /** After this time we stop looking for response among incoming messages */
 export const SERVER_RESPONSE_TIMEOUT = 10_000;
 
-// TODO: set as env variable
-export const SERVER_URL = 'ws://localhost:3001/ws';
+export const SERVER_URL = process.env.FULL_WEBSOCKET_URL || 'ws://localhost:3001/ws';


### PR DESCRIPTION
Quick and dirty, but should get the job done.

I'll pass `--env FULL_WEBSOCKET_URL='ws://trunkless-whiteboard.website/ws'` to `docker run`.