### PR TITLE
Add 'uuid' package to root-level dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "exec:prod": "node ./dist/index.js"
   },
   "devDependencies": {
+    "@types/uuid": "^8.3.0",
     "concurrently": "^6.0.0",
     "eslint": "^7.20.0",
     "eslint-config-prettier": "^7.2.0",
@@ -28,7 +29,6 @@
     "prettier": "^2.2.1"
   },
   "dependencies": {
-    "@types/uuid": "^8.3.0",
     "ts-proto": "^1.69.0",
     "uuid": "^8.3.2"
   }

--- a/package.json
+++ b/package.json
@@ -28,6 +28,8 @@
     "prettier": "^2.2.1"
   },
   "dependencies": {
-    "ts-proto": "^1.69.0"
+    "@types/uuid": "^8.3.0",
+    "ts-proto": "^1.69.0",
+    "uuid": "^8.3.2"
   }
 }


### PR DESCRIPTION
This ensures that the newest version of the package is available to the production build of the backend.