### PR TITLE
Reintroduce note move

### DIFF
--- a/packages/backend/src/models/whiteboard.ts
+++ b/packages/backend/src/models/whiteboard.ts
@@ -56,7 +56,6 @@ export enum OperationType {
   NOTE_MOVE,
   NOTE_DELETE,
   IMG_ADD,
-  IMG_MOVE,
   ADD_PENDING_CLIENT,
   APPROVE_PENDING_CLIENT,
   DENY_PENDING_CLIENT
@@ -139,13 +138,6 @@ export type Operation =
       type: OperationType.IMG_ADD;
       data: {
         img: Img;
-        causedBy: ClientToServerMessage['messageId'];
-      };
-    }
-  | {
-      type: OperationType.IMG_MOVE;
-      data: {
-        change: Pick<Img, 'id' | 'position'>;
         causedBy: ClientToServerMessage['messageId'];
       };
     };
@@ -402,37 +394,6 @@ export class Whiteboard {
             causedBy
           );
         }
-        break;
-      }
-      case OperationType.IMG_MOVE: {
-        const { change, causedBy } = op.data;
-        if (!this.areCoordsWithinBounds(change.position)) {
-          client.send(
-            resultToMessage({
-              result: 'error',
-              reason: ErrorReason.COORDINATES_OUT_OF_BOUNDS
-            }),
-            causedBy
-          );
-          return;
-        }
-        const img = this.images.get(change.id);
-        if (!img) {
-          client.send(
-            resultToMessage({
-              result: 'error',
-              reason: ErrorReason.FIGURE_NOT_EXISTS
-            }),
-            causedBy
-          );
-          return;
-        }
-        const updated = {
-          ...img,
-          position: change.position
-        };
-
-        this.images.set(img.id, updated);
         break;
       }
       case OperationType.ADD_PENDING_CLIENT: {


### PR DESCRIPTION
We accidentally remove the `NOTE_MOVE` operation from our backend in https://github.com/wgslr/trunkless-whiteboard/pull/32. Re-introduce it here.

Specific changes that got reverted: https://github.com/wgslr/trunkless-whiteboard/pull/32/files#r598731043

_Also remove the unused `IMG_MOVE` operation._