### PR TITLE
Enforce unique ids

### DIFF
--- a/packages/backend/src/encoding.ts
+++ b/packages/backend/src/encoding.ts
@@ -1,30 +1,18 @@
 import { decodeUUID, encodeUUID } from 'encoding';
-import { encode } from 'node:punycode';
 import * as uuid from 'uuid';
-import { Note, Line, Img } from './models/whiteboard';
+import { Img, Line, Note } from './models/whiteboard';
 import {
   ClientToServerMessage,
   ErrorReason,
+  Image as ImageProto,
   Line as LineProto,
   Note as NoteProto,
-  Image as ImageProto,
   ServerToClientMessage
 } from './protocol/protocol';
-import type { Result } from './types';
 
 export type ClientToServerCase = NonNullable<
   ClientToServerMessage['body']
 >['$case'];
-
-export const resultToMessage = (
-  result: Result
-): ServerToClientMessage['body'] => {
-  if (result.result === 'success') {
-    return makeSuccessMessage();
-  } else {
-    return makeErrorMessage(result.reason);
-  }
-};
 
 export const makeSuccessMessage = (): ServerToClientMessage['body'] => ({
   $case: 'success',

--- a/packages/backend/src/models/whiteboard.ts
+++ b/packages/backend/src/models/whiteboard.ts
@@ -2,12 +2,7 @@
 import { encodeUUID } from 'encoding';
 import fp from 'lodash/fp';
 import { v4 as uuidv4 } from 'uuid';
-import {
-  imageToMessage,
-  makeErrorMessage,
-  noteToMessage,
-  resultToMessage
-} from '../encoding';
+import { imageToMessage, makeErrorMessage, noteToMessage } from '../encoding';
 import logger from '../lib/logger';
 import {
   ClientToServerMessage,
@@ -211,10 +206,7 @@ export class Whiteboard {
         const line = this.lines.get(patch.id);
         if (!line) {
           client.send(
-            resultToMessage({
-              result: 'error',
-              reason: ErrorReason.FIGURE_NOT_EXISTS
-            }),
+            makeErrorMessage(ErrorReason.FIGURE_NOT_EXISTS),
             causedBy
           );
           return;
@@ -243,10 +235,7 @@ export class Whiteboard {
         const line = this.lines.get(patch.id);
         if (!line) {
           client.send(
-            resultToMessage({
-              result: 'error',
-              reason: ErrorReason.FIGURE_NOT_EXISTS
-            }),
+            makeErrorMessage(ErrorReason.FIGURE_NOT_EXISTS),
             causedBy
           );
           return;
@@ -283,10 +272,7 @@ export class Whiteboard {
         const line = this.lines.get(lineId);
         if (!line) {
           client.send(
-            resultToMessage({
-              result: 'error',
-              reason: ErrorReason.FIGURE_NOT_EXISTS
-            }),
+            makeErrorMessage(ErrorReason.FIGURE_NOT_EXISTS),
             causedBy
           );
           return;
@@ -318,10 +304,7 @@ export class Whiteboard {
         };
         if (!this.areCoordsWithinBounds(note.position)) {
           client.send(
-            resultToMessage({
-              result: 'error',
-              reason: ErrorReason.COORDINATES_OUT_OF_BOUNDS
-            }),
+            makeErrorMessage(ErrorReason.COORDINATES_OUT_OF_BOUNDS),
             causedBy
           );
         } else {
@@ -343,10 +326,7 @@ export class Whiteboard {
         const note = this.notes.get(change.id);
         if (!note) {
           client.send(
-            resultToMessage({
-              result: 'error',
-              reason: ErrorReason.FIGURE_NOT_EXISTS
-            }),
+            makeErrorMessage(ErrorReason.FIGURE_NOT_EXISTS),
             causedBy
           );
           return;
@@ -384,10 +364,7 @@ export class Whiteboard {
           );
         } else {
           client.send(
-            resultToMessage({
-              result: 'error',
-              reason: ErrorReason.FIGURE_NOT_EXISTS
-            }),
+            makeErrorMessage(ErrorReason.FIGURE_NOT_EXISTS),
             causedBy
           );
         }
@@ -397,10 +374,7 @@ export class Whiteboard {
         const { change, causedBy } = op.data;
         if (change.position && !this.areCoordsWithinBounds(change.position)) {
           client.send(
-            resultToMessage({
-              result: 'error',
-              reason: ErrorReason.COORDINATES_OUT_OF_BOUNDS
-            }),
+            makeErrorMessage(ErrorReason.COORDINATES_OUT_OF_BOUNDS),
             causedBy
           );
           return;
@@ -408,10 +382,7 @@ export class Whiteboard {
         const note = this.notes.get(change.id);
         if (!note) {
           client.send(
-            resultToMessage({
-              result: 'error',
-              reason: ErrorReason.FIGURE_NOT_EXISTS
-            }),
+            makeErrorMessage(ErrorReason.FIGURE_NOT_EXISTS),
             causedBy
           );
           return;
@@ -449,10 +420,7 @@ export class Whiteboard {
         };
         if (!this.areCoordsWithinBounds(img.position)) {
           client.send(
-            resultToMessage({
-              result: 'error',
-              reason: ErrorReason.COORDINATES_OUT_OF_BOUNDS
-            }),
+            makeErrorMessage(ErrorReason.COORDINATES_OUT_OF_BOUNDS),
             causedBy
           );
         } else {

--- a/packages/backend/src/models/whiteboard.ts
+++ b/packages/backend/src/models/whiteboard.ts
@@ -179,6 +179,13 @@ export class Whiteboard {
     switch (op.type) {
       case OperationType.LINE_CREATE: {
         const { line, causedBy } = op.data;
+        if (this.lines.has(line.id)) {
+          client.send(
+            makeErrorMessage(ErrorReason.ID_CONFLICT),
+            op.data.causedBy
+          );
+          return;
+        }
         const sanitizedLine = {
           id: line.id,
           points: this.removeInvalidCoords(line.points)
@@ -298,6 +305,13 @@ export class Whiteboard {
       case OperationType.NOTE_ADD: {
         // TODO validate unique id
         const { note: noteData, causedBy } = op.data;
+        if (this.notes.has(noteData.id)) {
+          client.send(
+            makeErrorMessage(ErrorReason.ID_CONFLICT),
+            op.data.causedBy
+          );
+          return;
+        }
         const note: Note = {
           ...noteData,
           creatorId: client.id
@@ -422,6 +436,13 @@ export class Whiteboard {
       }
       case OperationType.IMG_ADD: {
         const { img: imgData, causedBy } = op.data;
+        if (this.images.has(imgData.id)) {
+          client.send(
+            makeErrorMessage(ErrorReason.ID_CONFLICT),
+            op.data.causedBy
+          );
+          return;
+        }
         const img: Img = {
           ...imgData,
           zIndex: this.images.size

--- a/protocol/protocol.proto
+++ b/protocol/protocol.proto
@@ -7,9 +7,11 @@ enum ErrorReason {
   WHITEBOARD_DOES_NOT_EXIST = 1;
   COORDINATES_OUT_OF_BOUNDS = 2;
   FIGURE_NOT_EXISTS = 3;
-  INTERNAL_SERVER_ERROR = 4;
-  INVALID_MESSAGE = 5;
-  USER_DOES_NOT_EXIST = 6;
+  // returned when client tries to create a figure with a non-unique ID
+  ID_CONFLICT = 4;
+  INTERNAL_SERVER_ERROR = 5;
+  INVALID_MESSAGE = 6;
+  USER_DOES_NOT_EXIST = 7;
 }
 
 message User {


### PR DESCRIPTION
Add verification that a client does not try to create a figure with an already taken ID.
Should have no effect on our well-behaved, ranom-id-generating client.